### PR TITLE
Implement layabout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ lint: ## check style with flake8
 	flake8 $(SRC) tests
 
 type-check: ## run static analysis with mypy
-	mypy --ignore-missing-imports $(SRC)
+	mypy --ignore-missing-imports --disallow-untyped-defs $(SRC)
 
 test: ## run tests with pytest
 	pytest

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,18 @@
 Layabout
 ========
 
+.. image:: https://img.shields.io/travis/reillysiemens/layabout/master.svg?style=flat-square&label=build
+    :target: https://travis-ci.org/reillysiemens/layabout
+    :alt: Unix build status on Travis CI
+
+.. image:: https://img.shields.io/coveralls/reillysiemens/layabout/master.svg?style=flat-square&label=coverage
+    :target: https://coveralls.io/github/reillysiemens/layabout?branch=master
+    :alt: Code coverage on Coveralls
+
+.. image:: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
+    :target: https://github.com/reillysiemens/layabout/blob/master/LICENSE
+    :alt: ISC Licensed
+
 A small event handling library on top of the Slack RTM API.
 
 - Documentation: TODO

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 -r test-requirements.txt
-Sphinx==1.7.0
-sphinx-autodoc-typehints==1.2.5
+Sphinx
+sphinx-autodoc-typehints

--- a/layabout.py
+++ b/layabout.py
@@ -47,10 +47,10 @@ class Layabout:
     Args:
         name: A unique name for this :obj:`Layabout` instance.
         env_var: The environment variable to try to load a Slack API token
-            from. Defaults to ``SLACK_API_TOKEN``.
+            from.
 
     Attributes:
-        name: A unique name for this :obj:`Layabout` instance.
+        name (str): A unique name for this :obj:`Layabout` instance.
         slack (SlackClient): A :obj:`slackclient.SlackClient` instance.
             Initially :obj:`None`, the attribute is set after calling the
             :obj:`Layabout.connect` or :obj:`Layabout.run`
@@ -104,7 +104,7 @@ class Layabout:
 
         Raises:
             TypeError: If the decorated :obj:`Callable`'s signature does not
-                permit at least 2 parameters.
+                accept at least 2 parameters.
         """
         def decorator(fn: Callable) -> Callable:
             # Validate that the wrapped callable is a suitable event handler.
@@ -143,7 +143,7 @@ class Layabout:
                 an environment variable will be used.
 
         Returns:
-            bool: Whether the connection succeeded.
+            Whether the connection succeeded.
 
         Raises:
             MissingSlackToken: If no API token is available.
@@ -163,7 +163,7 @@ class Layabout:
                 self._token = os.environ[self._env_var]
             except KeyError:
                 raise MissingSlackToken('Cannot connect to the Slack API'
-                                        ' without a token.')
+                                        ' without a token')
 
         # Either we've never connected before or we're purposefully resetting
         # the connection.
@@ -181,14 +181,14 @@ class Layabout:
         Attempt to reconnect to the Slack API.
 
         Args:
-            retries (int): The number of retry attempts to make if a connection
+            retries: The number of retry attempts to make if a connection
                 to Slack if not established or is lost.
-            backoff (Callable): The strategy used to determine how
+            backoff: The strategy used to determine how
                 long to wait between retries. Must take as input the number of
                 the current retry and output a :obj:`float`.
 
         Returns:
-            bool: Whether the reconnection succeeded.
+            Whether the reconnection succeeded.
         """
         # TODO: Should retries start at 0 or 1?
         for retry in range(retries):
@@ -209,8 +209,7 @@ class Layabout:
 
         Args:
             token: A Slack API token. If absent an attempt will be made to use
-                the environment variable supplied at instantiation. Defaults
-                to ``None``.
+                the environment variable supplied at instantiation.
             interval: The number of seconds to wait between fetching events
                 from the Slack API.
             retries: The number of retry attempts to make if a connection to
@@ -237,7 +236,7 @@ class Layabout:
                 raise FailedConnection('Failed to connect to the Slack API')
 
         # TODO: Should we force callers to handle KeyboardInterrupt on their
-        # own, or should we try to handler it for them? 🤔
+        # own, or should we try to handle it for them? 🤔
         while True:
             try:
                 # Fetch new RTM events from the API.
@@ -279,8 +278,10 @@ class Layabout:
 
 
 def _forever(events: List[dict]) -> bool:  # pragma: no cover
+    """ Run Layabout in an infinite loop. """
     return True
 
 
 def _exponential(retry: int) -> float:
+    """ An exponential backoff strategy for reconnecting to the Slack API. """
     return (2 ** retry) / 8

--- a/layabout.py
+++ b/layabout.py
@@ -107,6 +107,7 @@ class _SlackClientWrapper:
             log.debug('Lost connection to the Slack API, attempting to '
                       'reconnect')
             self.connect_with_retry()
+            return []
 
 
 class Layabout:

--- a/layabout.py
+++ b/layabout.py
@@ -175,6 +175,7 @@ class Layabout:
         # TODO: Should retries start at 0 or 1?
         for retry in range(retries):
             if self._connect():
+                log.debug('Reconnected to the Slack API')
                 return True
             else:
                 interval = backoff(retry)
@@ -232,10 +233,8 @@ class Layabout:
             except (WebSocketConnectionClosedException, TimeoutError):
                 log.debug('Lost connection to the Slack API, attempting to '
                           'reconnect')
-                # Attempt to re-use our existing SlackClient and token.
+                # Attempt to reconnect with our existing SlackClient and token.
                 if self._reconnect(retries=retries, backoff=backoff):
-                    log.debug('Reconnected to the Slack API')
-                    # We continue so we can fetch new events before proceeding.
                     continue
 
                 raise FailedConnection('Failed to reconnect to the Slack API')

--- a/layabout.py
+++ b/layabout.py
@@ -19,11 +19,6 @@ from collections import defaultdict
 
 from slackclient import SlackClient
 
-# TODO: This is a dependency of slackclient needed for exception handling. In
-# the future, we might be able to remove this. For now we don't want to declare
-# it as an explicit dependency.
-from websocket import WebSocketConnectionClosedException
-
 __author__ = 'Reilly Tucker Siemens'
 __email__ = 'reilly@tuckersiemens.com'
 __version__ = '1.0.0b'
@@ -104,14 +99,11 @@ class _SlackClientWrapper:
         try:
             return self.inner.rtm_read()
 
-        # This is necessary to handle an error caused by a bug in Slack's
-        # Python client. For more information see
-        # https://github.com/slackhq/python-slackclient/issues/127
-        #
         # TODO: The TimeoutError could be more elegantly resolved by making
         # a PR to the websocket-client library and letting them coerce that
-        # exception to a WebSocketTimeoutException.
-        except (WebSocketConnectionClosedException, TimeoutError):
+        # exception to a WebSocketTimeoutException that could be caught by
+        # the slackclient library and then we could just use auto_reconnect.
+        except TimeoutError:
             log.debug('Lost connection to the Slack API, attempting to '
                       'reconnect')
             self.connect_with_retry()

--- a/layabout.py
+++ b/layabout.py
@@ -211,11 +211,9 @@ class Layabout:
         backoff = backoff or _exponential
         until = until or _forever
 
-        # The initial connection may use a given token or attempt to use an
-        # environment variable.
-        if not self._connect(token=token):
-            if not self._reconnect(retries=retries, backoff=backoff):
-                raise FailedConnection('Failed to connect to the Slack API')
+        if not (self._connect(token=token)
+                or self._reconnect(retries=retries, backoff=backoff)):
+            raise FailedConnection('Failed to connect to the Slack API')
 
         # TODO: Should we force callers to handle KeyboardInterrupt on their
         # own, or should we try to handle it for them? 🤔

--- a/layabout.py
+++ b/layabout.py
@@ -261,6 +261,7 @@ class Layabout:
             retries=retries,
             backoff=backoff
         )
+        assert self._slack is not None
 
         while True:
             events = self._slack.fetch_events()

--- a/layabout.py
+++ b/layabout.py
@@ -8,6 +8,7 @@ from typing import (
     DefaultDict,
     Dict,
     List,
+    NoReturn,
     Optional,
     Tuple,
     Union,
@@ -218,7 +219,7 @@ class Layabout:
                       backoff: Callable[[int], float]) -> None:
         """ Ensure we have a SlackClient. """
         connector = self._env_var if connector is None else connector
-        slack = _create_slack(connector)
+        slack: SlackClient = _create_slack(connector)
         self._slack = _SlackClientWrapper(
             slack=slack,
             retries=retries,
@@ -288,13 +289,13 @@ class Layabout:
 
 
 @singledispatch
-def _create_slack(connector: Any):
+def _create_slack(connector: Any) -> NoReturn:
     """ Default connector. Raises an error with unsupported connectors. """
     raise TypeError(f"Invalid connector: {type(connector)}")
 
 
 @_create_slack.register(str)
-def _create_slack_with_string(string: str):
+def _create_slack_with_string(string: str) -> NoReturn:
     """ Direct users to prefer :obj:`Token` and :obj:`EnvVar` over strings. """
     raise TypeError("Use layabout.Token or layabout.EnvVar instead of str")
 

--- a/layabout.py
+++ b/layabout.py
@@ -51,8 +51,7 @@ class Layabout:
     Attributes:
         slack (SlackClient): A :obj:`slackclient.SlackClient` instance.
             Initially :obj:`None`, the attribute is set after calling the
-            :obj:`Layabout.connect` or :obj:`Layabout.run`
-            methods.
+            :obj:`Layabout.run` method.
 
     Example:
 
@@ -123,16 +122,9 @@ class Layabout:
             return wrapper
         return decorator
 
-    def connect(self, token: str = None) -> bool:
+    def _connect(self, token: str = None) -> bool:
         """
         Attempt to establish or reset a connection to Slack's API.
-
-        Note:
-            It isn't normally necessary to use this method as
-            :obj:`Layabout.run` will take care of establishing a connection for
-            you. This is mostly helpful if you want to take advantage of the
-            embedded :obj:`slackclient.SlackClient` on the :obj:`Layabout`
-            instance *before* entering into the :obj:`Layabout.run` loop.
 
         Args:
             token: A Slack API token. If given it will override an existing
@@ -187,7 +179,7 @@ class Layabout:
         """
         # TODO: Should retries start at 0 or 1?
         for retry in range(retries):
-            if self.connect():
+            if self._connect():
                 return True
             else:
                 interval = backoff(retry)
@@ -226,7 +218,7 @@ class Layabout:
 
         # The initial connection may use a given token or attempt to use an
         # environment variable.
-        if not self.connect(token=token):
+        if not self._connect(token=token):
             if not self._reconnect(retries=retries, backoff=backoff):
                 raise FailedConnection('Failed to connect to the Slack API')
 

--- a/layabout.py
+++ b/layabout.py
@@ -70,14 +70,13 @@ class Layabout:
 
            layabout.run()
     """
-    def __init__(self, env_var: str = 'SLACK_API_TOKEN') -> None:
-        # TODO: Consider keyword only arguments.
+    def __init__(self, *, env_var: str = 'SLACK_API_TOKEN') -> None:
         self._env_var = env_var
         self._token: str = None
         self._slack: SlackClient = None
         self._handlers: _Handlers = defaultdict(list)
 
-    def handle(self, type: str, kwargs: dict = None) -> Callable:
+    def handle(self, type: str, *, kwargs: dict = None) -> Callable:
         """
         Register an event handler with the :obj:`Layabout` instance.
 
@@ -184,7 +183,7 @@ class Layabout:
 
         return False
 
-    def run(self, token: str = None, interval: float = 0.5,
+    def run(self, *, token: str = None, interval: float = 0.5,
             retries: int = 4, backoff: Callable[[int], float] = None,
             until: Callable[[List[dict]], bool] = None) -> None:
         """

--- a/layabout.py
+++ b/layabout.py
@@ -301,21 +301,17 @@ def _create_slack_with_string(string: str):
 def _create_slack_with_env_var(env_var: EnvVar) -> SlackClient:
     """ Create a SlackClient with a token from an env var. """
     token = os.getenv(env_var)
-    if not token:
-        raise MissingSlackToken("Could not acquire token from "
-                                f"{env_var}")
-
-    return SlackClient(token=token)
+    if token:
+        return SlackClient(token=token)
+    raise MissingSlackToken(f"Could not acquire token from {env_var}")
 
 
 @_create_slack.register(Token)
 def _create_slack_with_token(token: Token) -> SlackClient:
     """ Create a SlackClient with a provided token. """
-    if token == Token(''):
-        raise MissingSlackToken("The empty string is an invalid Slack API "
-                                "token")
-
-    return SlackClient(token=token)
+    if token != Token(''):
+        return SlackClient(token=token)
+    raise MissingSlackToken("The empty string is an invalid Slack API token")
 
 
 @_create_slack.register(SlackClient)

--- a/layabout.py
+++ b/layabout.py
@@ -13,7 +13,7 @@ from typing import (
     Union,
 )
 from inspect import signature, Signature
-from functools import singledispatch, update_wrapper, wraps
+from functools import singledispatch, wraps
 from collections import defaultdict
 
 from slackclient import SlackClient

--- a/layabout.py
+++ b/layabout.py
@@ -45,12 +45,10 @@ class Layabout:
     An event handler on top of the Slack RTM API.
 
     Args:
-        name: A unique name for this :obj:`Layabout` instance.
         env_var: The environment variable to try to load a Slack API token
             from.
 
     Attributes:
-        name (str): A unique name for this :obj:`Layabout` instance.
         slack (SlackClient): A :obj:`slackclient.SlackClient` instance.
             Initially :obj:`None`, the attribute is set after calling the
             :obj:`Layabout.connect` or :obj:`Layabout.run`
@@ -62,7 +60,7 @@ class Layabout:
 
            from layabout import Layabout
 
-           layabout = Layabout('app')
+           layabout = Layabout()
 
 
            @layabout.handle('message')
@@ -78,9 +76,8 @@ class Layabout:
 
            layabout.run()
     """
-    def __init__(self, name: str, env_var: str = 'SLACK_API_TOKEN') -> None:
+    def __init__(self, env_var: str = 'SLACK_API_TOKEN') -> None:
         # TODO: Consider keyword only arguments.
-        self.name = name
         self._env_var = env_var
         self._token: str = None
         self.slack: SlackClient = None
@@ -168,8 +165,6 @@ class Layabout:
         # Either we've never connected before or we're purposefully resetting
         # the connection.
         if self.slack is None or resetting:
-            # TODO: Maybe set an appropriate user agent string here using
-            # self.name.
             self.slack = SlackClient(token=self._token)
 
         # Use whatever token we've got to attempt to connect (or reconnect).

--- a/layabout.py
+++ b/layabout.py
@@ -270,8 +270,7 @@ class Layabout:
             # Handle events!
             for event in events:
                 type_ = event.get('type')
-                # TODO: Should * handlers be run first?
-                for handler in self._handlers['*'] + self._handlers[type_]:
+                for handler in self._handlers[type_] + self._handlers['*']:
                     fn, kwargs = handler
                     fn(self._slack, event, **kwargs)
 

--- a/layabout.py
+++ b/layabout.py
@@ -1,3 +1,285 @@
+import os
+import time
+import logging
+from typing import Any, DefaultDict, Callable, List, Tuple
+from inspect import signature
+from functools import wraps
+from collections import defaultdict
+
+from slackclient import SlackClient
+
+# TODO: This is a dependency of slackclient needed for exception handling. In
+# the future, we might be able to remove this. For now we don't want to declare
+# it as an explicit dependency.
+from websocket import WebSocketConnectionClosedException
+
 __author__ = 'Reilly Tucker Siemens'
 __email__ = 'reilly@tuckersiemens.com'
-__version__ = '0.1.0'
+__version__ = '1.0.0b'
+
+# Type alias for the complex type signature of the handlers defaultdict.
+Handlers = DefaultDict[str, List[Tuple[Callable, dict]]]
+
+log = logging.getLogger(__name__)
+
+
+class LayaboutError(Exception):
+    """ Base error for all Layabout exceptions. """
+
+
+class MissingSlackToken(LayaboutError):
+    """ Raised if a Slack API token could not be found. """
+
+
+class FailedConnection(LayaboutError, ConnectionError):
+    """
+    Raised if the Slack client could not connect to the Slack API.
+
+    Inherits from both :obj:`LayaboutError` and the built-in
+    :obj:`ConnectionError` for convenience in exception handling.
+    """
+
+
+class Layabout:
+    """
+    An event handler on top of the Slack RTM API.
+
+    Args:
+        name: A unique name for this :obj:`Layabout` instance.
+        env_var: The environment variable to try to load a Slack API token
+            from. Defaults to ``SLACK_API_TOKEN``.
+
+    Attributes:
+        name: A unique name for this :obj:`Layabout` instance.
+        slack (SlackClient): A :obj:`slackclient.SlackClient` instance.
+            Initially :obj:`None`, the attribute is set after calling the
+            :obj:`Layabout.connect` or :obj:`Layabout.run`
+            methods.
+
+    Example:
+
+        .. code-block:: python
+
+           from layabout import Layabout
+
+           layabout = Layabout('app')
+
+
+           @layabout.handle('message')
+           def echo(slack, event):
+               \"\"\" Echo all messages seen by the app. \"\"\"
+               channel = event['channel']
+               message = event['text']
+               subtype = event.get('subtype')
+
+               # Avoid an infinite loop of echoing our own messages.
+               if subtype != 'bot_message':
+                   slack.rtm_send_message(channel, message)
+
+           layabout.run()
+    """
+    def __init__(self, name: str, env_var: str = 'SLACK_API_TOKEN') -> None:
+        # TODO: Consider keyword only arguments.
+        self.name = name
+        self._env_var = env_var
+        self._token: str = None
+        self.slack: SlackClient = None
+        self._handlers: Handlers = defaultdict(list)
+
+    def handle(self, type: str, kwargs: dict = None) -> Callable:
+        """
+        Register an event handler with the :obj:`Layabout` instance.
+
+        Args:
+            type: The name of a Slack RTM API event to be handled. As a
+                special case, although it is not a proper RTM event, ``*`` may
+                be provided to handle all events. For more information about
+                available events see the
+                `Slack RTM API <https://api.slack.com/rtm>`_.
+            kwargs: Optional arbitrary keyword arguments passed to the event
+                handler when the event is triggered.
+
+        Returns:
+            A decorator that validates and registers a Layabout event handler.
+
+        Raises:
+            TypeError: If the decorated :obj:`Callable`'s signature does not
+                permit at least 2 parameters.
+        """
+        def _decorator(fn: Callable):
+            # Validate that the wrapped callable is a suitable event handler.
+            sig = signature(fn)
+            if len(sig.parameters) < 2:
+                raise TypeError("Layabout event handlers take at least 2 "
+                                "positional arguments, a slack client and an "
+                                "event")
+
+            # Register a tuple of the callable and its kwargs, if any.
+            self._handlers[type].append((fn, kwargs or {}))
+
+            @wraps(fn)
+            def _wrapper(*args: Any, **kwargs: Any) -> Any:
+                # We don't actually do anything with the return value, but this
+                # might make unit testing easier for users.
+                return fn(*args, **kwargs)
+            return _wrapper
+        return _decorator
+
+    def connect(self, token: str = None) -> bool:
+        """
+        Attempt to establish or reset a connection to Slack's API.
+
+        Note:
+            It isn't normally necessary to use this method as
+            :obj:`Layabout.run` will take care of establishing a connection for
+            you. This is mostly helpful if you want to take advantage of the
+            embedded :obj:`slackclient.SlackClient` on the :obj:`Layabout`
+            instance *before* entering into the :obj:`Layabout.run` loop.
+
+        Args:
+            token: A Slack API token. If given it will override an existing
+                connection (if one exists), otherwise an existing token or
+                an environment variable will be used.
+
+        Returns:
+            bool: Whether the connection succeeded.
+
+        Raises:
+            MissingSlackToken: If no API token is available.
+        """
+        resetting = False
+
+        # If we were given a token let's prefer the new one and establish or
+        # reset the connection.
+        if token is not None:
+            self._token = token
+            resetting = True
+
+        # We don't have an existing token, so let's try to get one from an
+        # environment variable or give up.
+        if self._token is None:
+            try:
+                self._token = os.environ[self._env_var]
+            except KeyError:
+                raise MissingSlackToken('Cannot connect to the Slack API'
+                                        ' without a token.')
+
+        # Either we've never connected before or we're purposefully resetting
+        # the connection.
+        if self.slack is None or resetting:
+            # TODO: Maybe set an appropriate user agent string here using
+            # self.name.
+            self.slack = SlackClient(token=self._token)
+
+        # Use whatever token we've got to attempt to connect (or reconnect).
+        return self.slack.rtm_connect()
+
+    def _reconnect(self, retries: int,
+                   backoff: Callable[[int], float]) -> bool:
+        """
+        Attempt to reconnect to the Slack API.
+
+        Args:
+            retries (int): The number of retry attempts to make if a connection
+                to Slack if not established or is lost.
+            backoff (Callable): The strategy used to determine how
+                long to wait between retries. Must take as input the number of
+                the current retry and output a :obj:`float`.
+
+        Returns:
+            bool: Whether the reconnection succeeded.
+        """
+        # TODO: Should retries start at 0 or 1?
+        for retry in range(retries):
+            if self.connect():
+                return True
+            else:
+                interval = backoff(retry)
+                log.debug("Waiting %.3fs before retrying", interval)
+                time.sleep(interval)
+
+        return False
+
+    def run(self, token: str = None, interval: float = 0.5,
+            retries: int = 4, backoff: Callable[[int], float] = None,
+            until: Callable[[List[dict]], bool] = None) -> None:
+        """
+        Connect to the Slack API and run the event handler loop.
+
+        Args:
+            token: A Slack API token. If absent an attempt will be made to use
+                the environment variable supplied at instantiation. Defaults
+                to ``None``.
+            interval: The number of seconds to wait between fetching events
+                from the Slack API.
+            retries: The number of retry attempts to make if a connection to
+                Slack if not established or is lost.
+            backoff: The strategy used to determine how long to wait between
+                retries. Must take as input the number of the current retry and
+                output a :obj:`float`. If absent an exponential backoff
+                strategy will be used.
+            until: The condition used to evaluate whether this method
+                terminates. Must take as input an :obj:`list` of :obj:`dict`
+                representing Slack RTM API events and return a :obj:`bool`. If
+                absent this method will run forever.
+
+        Raises:
+            FailedConnection: If connecting to the Slack API fails.
+        """
+        backoff = backoff or _exponential
+        until = until or _forever
+
+        # The initial connection may use a given token or attempt to use an
+        # environment variable.
+        if not self.connect(token=token):
+            if not self._reconnect(retries=retries, backoff=backoff):
+                raise FailedConnection('Failed to connect to the Slack API')
+
+        # TODO: Should we force callers to handle KeyboardInterrupt on their
+        # own, or should we try to handler it for them? 🤔
+        while True:
+            try:
+                # Fetch new RTM events from the API.
+                events = self.slack.rtm_read()
+
+            # This is necessary to handle an error caused by a bug in Slack's
+            # Python client. For more information see
+            # https://github.com/slackhq/python-slackclient/issues/127
+            #
+            # TODO: The TimeoutError could be more elegantly resolved by making
+            # a PR to the websocket-client library and letting them coerce that
+            # exception to a WebSocketTimeoutException.
+            except (WebSocketConnectionClosedException, TimeoutError):
+                log.debug('Lost connection to the Slack API, attempting to '
+                          'reconnect')
+                # Attempt to re-use our existing SlackClient and token.
+                if self._reconnect(retries=retries, backoff=backoff):
+                    log.debug('Reconnected to the Slack API')
+                    # We continue so we can fetch new events before proceeding.
+                    continue
+
+                raise FailedConnection('Failed to reconnect to the Slack API')
+
+            if not until(events):
+                # TODO: Is this even a good debugging message?
+                log.debug('Terminal condition met')
+                break
+
+            # Handle events!
+            for event in events:
+                type_ = event.get('type')
+                # TODO: Should * handlers be run first?
+                for handler in self._handlers['*'] + self._handlers[type_]:
+                    fn, kwargs = handler
+                    fn(self.slack, event, **kwargs)
+
+            # Maybe don't pester the Slack API too much.
+            time.sleep(interval)
+
+
+def _forever(events: List[dict]) -> bool:  # pragma: no cover
+    return True
+
+
+def _exponential(retry: int) -> float:
+    return (2 ** retry) / 8

--- a/layabout.py
+++ b/layabout.py
@@ -218,7 +218,8 @@ class Layabout:
             backoff=backoff
         )
 
-    def run(self, *, connector: Union[EnvVar, Token, SlackClient, None] = None,
+    def run(self, *,
+            connector: Union[EnvVar, Token, SlackClient, None] = None,
             interval: float = 0.5, retries: int = 16,
             backoff: Callable[[int], float] = None,
             until: Callable[[List[dict]], bool] = None) -> None:
@@ -234,11 +235,12 @@ class Layabout:
             interval: The number of seconds to wait between fetching events
                 from the Slack API.
             retries: The number of retry attempts to make if a connection to
-                Slack if not established or is lost.
+                Slack is not established or is lost.
             backoff: The strategy used to determine how long to wait between
                 retries. Must take as input the number of the current retry and
-                output a :obj:`float`. If absent a `truncated exponential
-                backoff`_ strategy will be used.
+                output a :obj:`float`. The retry count begins at 1 and
+                continues up to ``retries``. If absent a
+                `truncated exponential backoff`_ strategy will be used.
             until: The condition used to evaluate whether this method
                 terminates. Must take as input a :obj:`list` of :obj:`dict`
                 representing Slack RTM API events and return a :obj:`bool`. If

--- a/layabout.py
+++ b/layabout.py
@@ -197,8 +197,7 @@ class Layabout:
         Returns:
             Whether the reconnection succeeded.
         """
-        # TODO: Should retries start at 0 or 1?
-        for retry in range(retries):
+        for retry in range(1, retries + 1):
             if self._connect():
                 log.debug('Reconnected to the Slack API')
                 return True

--- a/layabout.py
+++ b/layabout.py
@@ -262,7 +262,7 @@ class Layabout:
 
             # Handle events!
             for event in events:
-                type_ = event.get('type')
+                type_ = event.get('type', '')
                 for handler in self._handlers[type_] + self._handlers['*']:
                     fn, kwargs = handler
                     fn(self._slack.inner, event, **kwargs)

--- a/layabout.py
+++ b/layabout.py
@@ -263,8 +263,7 @@ class Layabout:
                 raise FailedConnection('Failed to reconnect to the Slack API')
 
             if not until(events):
-                # TODO: Is this even a good debugging message?
-                log.debug('Terminal condition met')
+                log.debug('Exiting event loop')
                 break
 
             # Handle events!

--- a/layabout.py
+++ b/layabout.py
@@ -241,8 +241,6 @@ class Layabout:
                 or self._reconnect(retries=retries, backoff=backoff)):
             raise FailedConnection('Failed to connect to the Slack API')
 
-        # TODO: Should we force callers to handle KeyboardInterrupt on their
-        # own, or should we try to handle it for them? 🤔
         while True:
             try:
                 # Fetch new RTM events from the API.

--- a/layabout.py
+++ b/layabout.py
@@ -2,7 +2,16 @@ import os
 import time
 import random
 import logging
-from typing import Any, DefaultDict, Dict, Callable, List, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 from inspect import signature, Signature
 from functools import singledispatch, update_wrapper, wraps
 from collections import defaultdict
@@ -132,7 +141,7 @@ class Layabout:
     """
     def __init__(self) -> None:
         self._env_var = EnvVar('SLACK_API_TOKEN')
-        self._slack: self._SlackClientWrapper = None
+        self._slack: Optional[_SlackClientWrapper] = None
         self._handlers: _Handlers = defaultdict(list)
 
     @staticmethod

--- a/layabout.py
+++ b/layabout.py
@@ -272,7 +272,7 @@ class Layabout:
 
 
 @singledispatch
-def _create_slack(connector: Any) -> None:
+def _create_slack(connector: Any):
     """ Default connector. Raises an error with unsupported connectors. """
     raise TypeError(f"Invalid connector: {type(connector)}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+slackclient==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-slackclient==1.1.2
+slackclient==1.2.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-flake8==3.5.0
-mypy==0.560
-pytest==3.4.0
-pytest-cov==2.5.1
+flake8
+mypy
+pytest
+pytest-cov

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -216,10 +216,8 @@ def test_layabout_raises_failed_connection_on_failed_connection(monkeypatch):
     API fails.
     """
     layabout = Layabout()
-    connections = [
-        False,  # Fail the initial connection (_connect).
-        False,  # Fail the reconnection attempt (_reconnect).
-    ]
+    # Fail the first connection and the subsequent reconnection.
+    connections = (False, False)
     SlackClient, _ = mock_slack(connections=connections)
 
     monkeypatch.setattr('layabout.SlackClient', SlackClient)
@@ -242,10 +240,8 @@ def test_layabout_raises_connection_error_on_failed_reconnection(monkeypatch):
     the Slack API fail.
     """
     layabout = Layabout()
-    connections = [
-        True,  # Succeed with the first connection (_connect).
-        False,  # Fail later during a reconnection (_reconnect).
-    ]
+    # Succeed with the first connection and fail the subsequent reconnection.
+    connections = (True, False)
     SlackClient, _ = mock_slack(connections=connections, reads=TimeoutError)
 
     monkeypatch.setattr('layabout.SlackClient', SlackClient)
@@ -269,11 +265,8 @@ def test_layabout_can_reuse_an_existing_client_to_reconnect(monkeypatch):
     reconnection attempt.
     """
     layabout = Layabout()
-    connections = [
-        False,  # Fail the initial connection (_connect).
-        False,  # Fail with the first reconnection attempt (_reconnect).
-        True,  # Succeed with the second reconnection attempt (_reconnect).
-    ]
+    # Fail initial connection, fail reconnection, succeed at last.
+    connections = (False, False, True)
     SlackClient, _ = mock_slack(connections=connections)
 
     monkeypatch.setattr('layabout.SlackClient', SlackClient)
@@ -298,14 +291,10 @@ def test_layabout_can_continue_after_successful_reconnection(monkeypatch):
     reconnecting to the Slack API.
     """
     layabout = Layabout()
-    connections = [
-        True,  # Succeed with the first connection (_connect).
-        True,  # Succeed later with a reconnection (_reconnect).
-    ]
-    reads = [
-        TimeoutError,  # Raise an exception on the first read.
-        [],  # Return empty events on the second read (after reconnection).
-    ]
+    # Succeed with the first connection and the subsequent reconnection.
+    connections = (True, True)
+    # Raise an exception on the first read and return empty events next.
+    reads = (TimeoutError, [])
     SlackClient, _ = mock_slack(connections=connections, reads=reads)
 
     monkeypatch.setattr('layabout.SlackClient', SlackClient)

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -30,7 +30,7 @@ def test_layabout_can_register_handlers():
     Test that layabout can register Slack API event handlers normally and as a
     decorator, both with and without keyword arguments.
     """
-    layabout = Layabout(name='test')
+    layabout = Layabout()
     kwargs = dict(spam='🍳')
 
     def handle_hello1(slack, event):
@@ -56,7 +56,7 @@ def test_layabout_raises_type_error_with_invalid_handlers():
     Test that layabout raises a TypeError if an event handler is supplied that
     doesn't meet the minimum criteria to be called correctly.
     """
-    layabout = Layabout(name='test')
+    layabout = Layabout()
 
     def invalid_handler1(slack):
         pass
@@ -80,7 +80,7 @@ def test_layabout_handlers_can_still_be_used_normally():
     though they were undecorated. Most importantly, that they can still return
     and that their docstrings are intact.
     """
-    layabout = Layabout(name='test')
+    layabout = Layabout()
     cheese_shop = dict(shop='🧀')
 
     @layabout.handle('hello')
@@ -97,7 +97,7 @@ def test_layabout_can_connect_to_slack_with_token(monkeypatch):
     Test that layabout can connect to the Slack API when given a valid Slack
     API token.
     """
-    layabout = Layabout(name='test')
+    layabout = Layabout()
 
     rtm_connect = MagicMock(return_value=True)
     slack = MagicMock(rtm_connect=rtm_connect)
@@ -119,7 +119,7 @@ def test_layabout_can_connect_to_slack_with_env_var(monkeypatch):
     """
     env_var = '_TEST_SLACK_API_TOKEN'
     environ = {env_var: TOKEN}
-    layabout = Layabout(name='test', env_var=env_var)
+    layabout = Layabout(env_var=env_var)
 
     rtm_connect = MagicMock(return_value=True)
     slack = MagicMock(rtm_connect=rtm_connect)
@@ -142,7 +142,7 @@ def test_layabout_raises_failed_connection_without_token(monkeypatch):
     for it to use.
     """
     environ = dict()
-    layabout = Layabout(name='test')
+    layabout = Layabout()
 
     monkeypatch.setattr(os, 'environ', environ)
 
@@ -158,7 +158,7 @@ def test_layabout_raises_failed_connection_on_failed_connection(monkeypatch):
     Test that layabout raises a FailedConnection if the connection to the Slack
     API fails.
     """
-    layabout = Layabout(name='test')
+    layabout = Layabout()
 
     connections = [
         False,  # Fail the initial connection (_connect).
@@ -187,7 +187,7 @@ def test_layabout_raises_connection_error_on_failed_reconnection(monkeypatch):
     Test that layabout raises a FailedConnection if attempts to reconnect to
     the Slack API fail.
     """
-    layabout = Layabout(name='test')
+    layabout = Layabout()
 
     connections = [
         True,  # Succeed with the first connection (_connect).
@@ -219,7 +219,7 @@ def test_layabout_can_reuse_an_existing_client_to_reconnect(monkeypatch):
     to the Slack API rather than needlessly instantiating a new one on each
     reconnection attempt.
     """
-    layabout = Layabout(name='test')
+    layabout = Layabout()
 
     connections = [
         False,  # Fail the initial connection (_connect).
@@ -251,7 +251,7 @@ def test_layabout_can_continue_after_successful_reconnection(monkeypatch):
     Test that layabout can continue to handle events after successfully
     reconnecting to the Slack API.
     """
-    layabout = Layabout(name='test')
+    layabout = Layabout()
 
     connections = [
         True,  # Succeed with the first connection (_connect).
@@ -286,7 +286,7 @@ def test_layabout_can_handle_events(monkeypatch):
         dict(type='hello'),
         dict(type='goodbye'),
     ]
-    layabout = Layabout(name='test')
+    layabout = Layabout()
 
     connections = [
         True,  # Succeed with the first connection (_connect).

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -9,8 +9,7 @@ from layabout import (
     FailedConnection,
 )
 
-# The likelihood of this ever being a valid Slack token is probably slim.
-TOKEN = 'xoxb-13376661337-DeAdb33Fd15EA53fACef33D1'
+TOKEN = "This ain't no Slack API token."
 
 
 @pytest.fixture

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -150,7 +150,7 @@ def test_layabout_raises_failed_connection_without_token(monkeypatch):
         # until will exit early here just to be safe.
         layabout.run(until=lambda e: False)
 
-    assert str(exc.value) == 'Cannot connect to the Slack API without a token.'
+    assert str(exc.value) == 'Cannot connect to the Slack API without a token'
 
 
 def test_layabout_raises_failed_connection_on_failed_connection(monkeypatch):

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -1,7 +1,6 @@
 import os
 from unittest.mock import MagicMock, call
 from typing import Iterable
-import random
 
 import pytest
 from slackclient import SlackClient

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -198,7 +198,7 @@ def test_layabout_can_connect_to_slack_with_env_var(monkeypatch):
     monkeypatch.setattr('layabout.SlackClient', SlackClient)
 
     # Purposefully don't provide a token so we have to use an env var.
-    layabout.run(until=lambda e: False)
+    layabout.run(token=None, until=lambda e: False)
 
     # Verify we instantiated a SlackClient with the given token and used it to
     # connect to the Slack API.

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -118,14 +118,14 @@ def test_layabout_raises_type_error_with_invalid_handler():
     """
     layabout = Layabout()
 
-    def invalid_handler(slack):
+    def invalid_handler():
         pass
 
     with pytest.raises(TypeError) as exc:
         layabout.handle(type='hello')(fn=invalid_handler)
 
-    expected = ("Layabout event handlers take at least 2 positional "
-                "arguments, a slack client and an event")
+    expected = ("invalid_handler() missing 2 required positional arguments: "
+                "'slack' and 'event'")
     assert str(exc.value) == expected
 
 
@@ -141,8 +141,8 @@ def test_layabout_raises_type_error_with_invalid_decorated_handler():
         def invalid_handler(slack):
             pass
 
-    expected = ("Layabout event handlers take at least 2 positional "
-                "arguments, a slack client and an event")
+    expected = ("invalid_handler(slack) missing 1 required positional "
+                "argument: 'event'")
     assert str(exc.value) == expected
 
 

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -1,1 +1,327 @@
-import layabout  # noqa: F401
+import os
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from layabout import (
+    Layabout,
+    MissingSlackToken,
+    FailedConnection,
+)
+
+# The likelihood of this ever being a valid Slack token is probably slim.
+TOKEN = 'xoxb-13376661337-DeAdb33Fd15EA53fACef33D1'
+
+
+@pytest.fixture
+def slack_client():
+    def api_call(method):
+        return dict(
+            channels=[{'id': 'D3ADB33F1', 'name': 'general'}],
+            groups=[{'id': '1800IDGAF', 'name': 'super_secret_club'}],
+        )
+
+    slack_client = MagicMock(api_call=api_call)
+    return slack_client
+
+
+def test_layabout_can_register_handlers():
+    """
+    Test that layabout can register Slack API event handlers normally and as a
+    decorator, both with and without keyword arguments.
+    """
+    layabout = Layabout(name='test')
+    kwargs = dict(spam='🍳')
+
+    def handle_hello1(slack, event):
+        pass
+
+    @layabout.handle('hello')
+    def handle_hello2(slack, event):
+        pass
+
+    def handle_hello3(slack, event, spam):
+        pass
+
+    @layabout.handle('hello', kwargs=kwargs)
+    def handle_hello4(slack, event, spam):
+        pass
+
+    layabout.handle(type='hello')(fn=handle_hello1)
+    layabout.handle(type='hello', kwargs=kwargs)(fn=handle_hello3)
+
+
+def test_layabout_raises_type_error_with_invalid_handlers():
+    """
+    Test that layabout raises a TypeError if an event handler is supplied that
+    doesn't meet the minimum criteria to be called correctly.
+    """
+    layabout = Layabout(name='test')
+
+    def invalid_handler1(slack):
+        pass
+
+    with pytest.raises(TypeError) as exc1:
+        layabout.handle(type='hello')(fn=invalid_handler1)
+
+    with pytest.raises(TypeError) as exc2:
+        @layabout.handle('hello')
+        def invalid_handler2(slack):
+            pass
+
+    expected = ("Layabout event handlers take at least 2 positional "
+                "arguments, a slack client and an event")
+    assert str(exc1.value) == expected and str(exc2.value) == expected
+
+
+def test_layabout_handlers_can_still_be_used_normally():
+    """
+    Test that layabout can decorate event handlers that can still be used as
+    though they were undecorated. Most importantly, that they can still return
+    and that their docstrings are intact.
+    """
+    layabout = Layabout(name='test')
+    cheese_shop = dict(shop='🧀')
+
+    @layabout.handle('hello')
+    def handle_hello(slack, event):
+        """ This docstring must be preserved. """
+        return cheese_shop
+
+    assert handle_hello(None, None) == cheese_shop
+    assert handle_hello.__doc__ == ' This docstring must be preserved. '
+
+
+def test_layabout_can_connect_to_slack_with_token(monkeypatch):
+    """
+    Test that layabout can connect to the Slack API when given a valid Slack
+    API token.
+    """
+    layabout = Layabout(name='test')
+
+    rtm_connect = MagicMock(return_value=True)
+    slack = MagicMock(rtm_connect=rtm_connect)
+    SlackClient = MagicMock(return_value=slack)
+    monkeypatch.setattr('layabout.SlackClient', SlackClient)
+
+    layabout.run(token=TOKEN, until=lambda e: False)
+
+    # Verify we instantiated a SlackClient with the given token and used it to
+    # connect to the Slack API.
+    SlackClient.assert_called_with(token=TOKEN)
+    rtm_connect.assert_called_with()
+
+
+def test_layabout_can_connect_to_slack_with_env_var(monkeypatch):
+    """
+    Test that layabout can discover and use a Slack API token from an
+    environment variable when not given one directly.
+    """
+    env_var = '_TEST_SLACK_API_TOKEN'
+    environ = {env_var: TOKEN}
+    layabout = Layabout(name='test', env_var=env_var)
+
+    rtm_connect = MagicMock(return_value=True)
+    slack = MagicMock(rtm_connect=rtm_connect)
+    SlackClient = MagicMock(return_value=slack)
+    monkeypatch.setattr(os, 'environ', environ)
+    monkeypatch.setattr('layabout.SlackClient', SlackClient)
+
+    # Purposefully don't provide a token so we have to use an env var.
+    layabout.run(until=lambda e: False)
+
+    # Verify we instantiated a SlackClient with the given token and used it to
+    # connect to the Slack API.
+    SlackClient.assert_called_with(token=TOKEN)
+    rtm_connect.assert_called_with()
+
+
+def test_layabout_raises_failed_connection_without_token(monkeypatch):
+    """
+    Test that layabout raises a FailedConnection if there is no Slack API token
+    for it to use.
+    """
+    environ = dict()
+    layabout = Layabout(name='test')
+
+    monkeypatch.setattr(os, 'environ', environ)
+
+    with pytest.raises(MissingSlackToken) as exc:
+        # until will exit early here just to be safe.
+        layabout.run(until=lambda e: False)
+
+    assert str(exc.value) == 'Cannot connect to the Slack API without a token.'
+
+
+def test_layabout_raises_failed_connection_on_failed_connection(monkeypatch):
+    """
+    Test that layabout raises a FailedConnection if the connection to the Slack
+    API fails.
+    """
+    layabout = Layabout(name='test')
+
+    connections = [
+        False,  # Fail the initial connection (_connect).
+        False,  # Fail the reconnection attempt (_reconnect).
+    ]
+
+    rtm_connect = MagicMock(side_effect=connections)
+    slack = MagicMock(rtm_connect=rtm_connect)
+    SlackClient = MagicMock(return_value=slack)
+    monkeypatch.setattr('layabout.SlackClient', SlackClient)
+
+    # Retry once after failure. until will exit early just to be safe.
+    with pytest.raises(FailedConnection) as exc:
+        layabout.run(
+            token=TOKEN,
+            retries=1,
+            backoff=lambda r: 0,
+            until=lambda e: False
+        )
+
+    assert str(exc.value) == 'Failed to connect to the Slack API'
+
+
+def test_layabout_raises_connection_error_on_failed_reconnection(monkeypatch):
+    """
+    Test that layabout raises a FailedConnection if attempts to reconnect to
+    the Slack API fail.
+    """
+    layabout = Layabout(name='test')
+
+    connections = [
+        True,  # Succeed with the first connection (_connect).
+        False,  # Fail later during a reconnection (_reconnect).
+    ]
+
+    rtm_connect = MagicMock(side_effect=connections)
+    rtm_read = MagicMock(side_effect=TimeoutError)
+    slack = MagicMock(rtm_connect=rtm_connect, rtm_read=rtm_read)
+
+    SlackClient = MagicMock(return_value=slack)
+    monkeypatch.setattr('layabout.SlackClient', SlackClient)
+
+    # Retry once after failure. until will exit early just to be safe. Don't
+    # provide a backoff callback so the default behavior will be tested.
+    with pytest.raises(FailedConnection) as exc:
+        layabout.run(
+            token=TOKEN,
+            retries=1,
+            until=lambda e: False
+        )
+
+    assert str(exc.value) == 'Failed to reconnect to the Slack API'
+
+
+def test_layabout_can_reuse_an_existing_client_to_reconnect(monkeypatch):
+    """
+    Test that layabout can reuse an existing SlackClient instance to reconnect
+    to the Slack API rather than needlessly instantiating a new one on each
+    reconnection attempt.
+    """
+    layabout = Layabout(name='test')
+
+    connections = [
+        False,  # Fail the initial connection (_connect).
+        False,  # Fail with the first reconnection attempt (_reconnect).
+        True,  # Succeed with the second reconnection attempt (_reconnect).
+    ]
+
+    rtm_connect = MagicMock(side_effect=connections)
+    slack = MagicMock(rtm_connect=rtm_connect)
+    SlackClient = MagicMock(return_value=slack)
+    monkeypatch.setattr('layabout.SlackClient', SlackClient)
+
+    # Retry connecting twice to verify reconnection logic was evaluated.
+    # until will exit early just to be safe.
+    layabout.run(
+        token=TOKEN,
+        retries=2,
+        backoff=lambda r: 0,
+        until=lambda e: False
+    )
+
+    # Make sure the SlackClient was only instantiated once so we know that we
+    # reused the existing instance.
+    SlackClient.assert_called_once_with(token=TOKEN)
+
+
+def test_layabout_can_continue_after_successful_reconnection(monkeypatch):
+    """
+    Test that layabout can continue to handle events after successfully
+    reconnecting to the Slack API.
+    """
+    layabout = Layabout(name='test')
+
+    connections = [
+        True,  # Succeed with the first connection (_connect).
+        True,  # Succeed later with a reconnection (_reconnect).
+    ]
+    reads = [
+        TimeoutError,  # Raise an exception on the first read.
+        [],  # Return empty events on the second read (after reconnection).
+    ]
+
+    rtm_connect = MagicMock(side_effect=connections)
+    rtm_read = MagicMock(side_effect=reads)
+    slack = MagicMock(rtm_connect=rtm_connect, rtm_read=rtm_read)
+
+    SlackClient = MagicMock(return_value=slack)
+    monkeypatch.setattr('layabout.SlackClient', SlackClient)
+
+    layabout.run(
+        token=TOKEN,
+        retries=1,
+        backoff=lambda r: 0,
+        until=lambda e: False
+    )
+
+
+def test_layabout_can_handle_events(monkeypatch):
+    """
+    Test that layabout can handle events appropriately given multiple event
+    handlers and even * event handlers.
+    """
+    events = [
+        dict(type='hello'),
+        dict(type='goodbye'),
+    ]
+    layabout = Layabout(name='test')
+
+    connections = [
+        True,  # Succeed with the first connection (_connect).
+    ]
+
+    rtm_connect = MagicMock(side_effect=connections)
+    rtm_read = MagicMock(return_value=events)
+    slack = MagicMock(rtm_connect=rtm_connect, rtm_read=rtm_read)
+    run_twice = MagicMock(side_effect=[True, False])
+
+    SlackClient = MagicMock(return_value=slack)
+    monkeypatch.setattr('layabout.SlackClient', SlackClient)
+
+    # Register our handlers to be called with the specified kwargs.
+    kwargs = dict(caerbannog='🐰')
+    handle_hello = MagicMock()
+    handle_goodbye = MagicMock()
+    handle_splat = MagicMock()
+    layabout.handle(type='hello', kwargs=kwargs)(fn=handle_hello)
+    layabout.handle(type='goodbye', kwargs=kwargs)(fn=handle_goodbye)
+    layabout.handle(type='*', kwargs=kwargs)(fn=handle_splat)
+
+    layabout.run(
+        token=TOKEN,
+        interval=0,
+        retries=0,
+        backoff=lambda r: 0,
+        until=run_twice
+    )
+
+    # Ensure the hello handler receives only hello events, the goodbye handler
+    # receives only goodbye events, and the * handler receives all events.
+    call_hello = call(layabout.slack, events[0], **kwargs)
+    call_goodbye = call(layabout.slack, events[1], **kwargs)
+    all_calls = [call_hello, call_goodbye]
+    handle_hello.assert_called_once_with(*call_hello[1], **call_hello[2])
+    handle_goodbye.assert_called_once_with(*call_goodbye[1], **call_goodbye[2])
+    handle_splat.assert_has_calls(all_calls)

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -10,11 +10,12 @@ from layabout import (
     FailedConnection,
     Layabout,
     MissingSlackToken,
+    Token,
     _SlackClientWrapper,
     _truncated_exponential,
 )
 
-TOKEN = "This ain't no Slack API token."
+TOKEN = Token("This ain't no Slack API token.")
 
 # ---- Auxiliary functions ----------------------------------------------------
 
@@ -231,18 +232,24 @@ def test_layabout_can_connect_to_slack_with_env_var(monkeypatch):
     SlackClient.assert_called_with(token=TOKEN)
 
 
-def test_layabout_can_connect_to_slack_with_existing_slack_client(monkeypatch):
+def test_layabout_can_connect_to_slack_with_existing_slack_client():
     """
-    TODO:
-        - make this test actually useful
-        - reorder conn tests
-        - test unconnected slack gets connected
-        - connected slack isn't touched
+    Test that layabout can use an existing SlackClient as a connector.
     """
     layabout = Layabout()
     _, slack = mock_slack(connections=(True,))
 
     layabout.run(connector=slack, until=lambda e: False)
+
+
+def test_layabout_raises_type_error_with_string_connector():
+    layabout = Layabout()
+
+    with pytest.raises(TypeError) as exc:
+        layabout.run(connector='', until=lambda e: False)
+
+    assert str(exc.value) == ('Use layabout.Token or layabout.EnvVar '
+                              'instead of str')
 
 
 def test_layabout_raises_missing_slack_token_without_token(monkeypatch):
@@ -271,7 +278,7 @@ def test_layabout_raises_missing_slack_token_with_empty_token():
 
     with pytest.raises(MissingSlackToken) as exc:
         # until will exit early here just to be safe.
-        layabout.run(connector='', until=lambda e: False)
+        layabout.run(connector=Token(''), until=lambda e: False)
 
     assert str(exc.value) == 'The empty string is an invalid Slack API token'
 

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -319,8 +319,8 @@ def test_layabout_can_handle_events(monkeypatch):
 
     # Ensure the hello handler receives only hello events, the goodbye handler
     # receives only goodbye events, and the * handler receives all events.
-    call_hello = call(layabout.slack, events[0], **kwargs)
-    call_goodbye = call(layabout.slack, events[1], **kwargs)
+    call_hello = call(layabout._slack, events[0], **kwargs)
+    call_goodbye = call(layabout._slack, events[1], **kwargs)
     all_calls = [call_hello, call_goodbye]
     handle_hello.assert_called_once_with(*call_hello[1], **call_hello[2])
     handle_goodbye.assert_called_once_with(*call_goodbye[1], **call_goodbye[2])

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -7,6 +7,7 @@ import pytest
 from slackclient import SlackClient
 
 from layabout import (
+    EnvVar,
     FailedConnection,
     Layabout,
     MissingSlackToken,
@@ -215,16 +216,16 @@ def test_layabout_can_connect_to_slack_with_env_var(monkeypatch):
     Test that layabout can discover and use a Slack API token from an
     environment variable when not given one directly.
     """
-    env_var = '_TEST_SLACK_API_TOKEN'
+    env_var = EnvVar('_TEST_SLACK_API_TOKEN')
     environ = {env_var: TOKEN}
-    layabout = Layabout(env_var=env_var)
+    layabout = Layabout()
     SlackClient, slack = mock_slack(connections=(True,))
 
     monkeypatch.setattr(os, 'environ', environ)
     monkeypatch.setattr('layabout.SlackClient', SlackClient)
 
     # Purposefully don't provide a connector so we have to use an env var.
-    layabout.run(connector=None, until=lambda e: False)
+    layabout.run(connector=env_var, until=lambda e: False)
 
     # Verify we instantiated a SlackClient with the given token and used it to
     # connect to the Slack API.


### PR DESCRIPTION
This provides the implementation and code coverage for Layabout. There are a few unanswered questions marked with `TODO`s that I'd like to resolve before officially publishing this. I'm also interested in feedback on the design now in this early stage, so anything is fair game.

In particular I'm curious about whether my very recent decision to make the `connect` method part of the public interface is a good idea. Previously I just had `handle` and `run`, but once I made the `slack` attribute containing the `slackclient.SlackClient` instance public it didn't seem right to not allow users to
use it right away before entering into the event loop.

If you have the time I highly recommend installing the library via from this branch and playing around with it to get a feel for it.
```bash
$ pip install git+https://github.com/reillysiemens/layabout.git@implement-layabout
```