### PR TITLE
Create a user guide. Fixes #3

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,11 +1,17 @@
+Authors
+=======
+
 Lead Developers
-~~~~~~~~~~~~~~~
+---------------
 
 - Tucker Siemens (`@reillysiemens <https://github.com/reillysiemens>`_)
 
-Contributors
-~~~~~~~~~~~~
+Contributors (alphabetical)
+---------------------------
 
 These folks have lent their support to the project in some way.
 
-- No one here! Why not be the first?
+- Alex LordThorsen (`@rawrgulmuffins <https://github.com/rawrgulmuffins>`_)
+- Geoff Shannon (`@RadicalZephyr <https://github.com/RadicalZephyr>`_)
+- Kyle Rader (`@kyle-rader <https://github.com/kyle-rader>`_)
+- Mike Canoy (`@solus-impar <https://github.com/solus-impar>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,13 @@
-v1.0.0b (2018-02-14)
-====================
+Changelog
+=========
 
-Initial beta release.
+v1.0.0b1 (2018-06-12)
+---------------------
+
+Beta release.
 
 Contributors
-------------
+~~~~~~~~~~~~
 
+- Mike Canoy (`@solus-impar <https://github.com/solus-impar>`_)
 - Tucker Siemens (`@reillysiemens <https://github.com/reillysiemens>`_)

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,5 +1,5 @@
-Contributor Covenant Code of Conduct
-====================================
+Code of Conduct
+===============
 
 Our Pledge
 ----------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,5 @@
-Contributing to this project
-============================
+Contributing Guidelines
+=======================
 
 Please follow these guidelines for contributing to this project.
 
@@ -7,7 +7,7 @@ Repository Management
 ---------------------
 
 - Fork this project into your own repository.
-- Follow the :ref:`version control <version_control>` guidelines.
+- Follow the `version control`_ guidelines.
 - No changes should reach the ``master`` branch except by way of a
   `pull request`_.
 
@@ -31,8 +31,8 @@ PRs must remain focused on fixing or addressing one thing (see `topic branch`_
 model). Make sure your pull request contains a clear title and description.
 Test coverage should not drop as a result. If you add code, you add tests.
 
-Be sure to follow the guidelines on :ref:`writing code <writing_code>` if you
-want your work considered for inclusion.
+Be sure to follow the guidelines on `writing code`_ if you want your work
+considered for inclusion.
 
 Handling Pull Requests
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -56,11 +56,11 @@ Nota Bene
   Progress) status will **not** be merged until the ``[WIP]`` prefix has been
   removed from the title. This is a good way to get feedback from maintainers
   if you are unsure of the changes you are making.
-- A PR that has received a 'Ship It' may not be accepted immediately.
+- A PR that has received a 'Ship It' may not be merged immediately.
 - You may be asked to rebase or squash your commits to keep an orderly version
   control history.
 
-.. _writing_code:
+.. _writing code:
 
 Writing Code
 ------------
@@ -70,13 +70,15 @@ Please follow these code conventions.
 Coding Style
 ~~~~~~~~~~~~
 
-- Follow `PEP8`_ guidelines
+- Follow :pep:`8` guidelines.
+- Try to respect the style of existing code.
+
+.. _version control:
 
 Version Control
 ~~~~~~~~~~~~~~~
 
-- :ref:`Fork <forking>` the :ref:`central repository <repo>` and work from a
-  clone of your own fork.
+- `Fork`_ the `central repository`_ and work from a clone of your own fork.
 - Follow the `topic branch`_ model and submit pull requests from branches named
   according to their purpose.
 - Review the `GitHub Flow`_ documentation and, in general, try to stick to the
@@ -87,8 +89,8 @@ Testing
 - Code **must** be tested. Write or update related unit tests so you don't have
   to manually retest the same thing many times.
 
-.. _repo: https://github.com/reillysiemens/layabout/
 .. _pull request: https://help.github.com/articles/using-pull-requests/
-.. _forking: https://help.github.com/articles/fork-a-repo/
 .. _topic branch: https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows#Topic-Branches
+.. _Fork: https://help.github.com/articles/fork-a-repo/
+.. _central repository: https://github.com/reillysiemens/layabout/
 .. _GitHub Flow: https://guides.github.com/introduction/flow/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,12 +65,16 @@ Nota Bene
 Writing Code
 ------------
 
-Please follow these code conventions.
+Writing code is a creative process and there will always be exceptions to the
+rules, but it's good to maintain certain standards. In general, please follow
+these code conventions.
 
 Coding Style
 ~~~~~~~~~~~~
 
 - Follow :pep:`8` guidelines.
+- Code in this project **must** be linted. For convenience the project Makefile
+  contains a ``lint`` target to run the linting process for you.
 - Try to respect the style of existing code.
 
 .. _version control:
@@ -88,9 +92,30 @@ Testing
 ~~~~~~~
 - Code **must** be tested. Write or update related unit tests so you don't have
   to manually retest the same thing many times.
+- Tests for this project are written using the `pytest`_ framework. While it
+  isn't always achievable this project strives to maintain 100% test coverage.
+  For convenience the project Makefile contains a ``test`` target to run the
+  tests and generate coverage for you.
+- In addition to unit testing code in this project is statically type checked
+  using `mypy`_. For convenience the project Makefile contains a ``type-check``
+  target to run mypy for you.
+
+Documentation
+~~~~~~~~~~~~~
+- Public interfaces **must** be thoroughly documented. At a minimum this
+  includes inputs, return types, exceptions raised, and surprising behavior
+  like state changes.
+- Documentation for this project is written in `reStructuredText`_ and
+  generated with `Sphinx`_. For convenience the project Makefile contains a
+  ``docs`` to run Sphinx for you.
+
 
 .. _pull request: https://help.github.com/articles/using-pull-requests/
 .. _topic branch: https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows#Topic-Branches
 .. _Fork: https://help.github.com/articles/fork-a-repo/
 .. _central repository: https://github.com/reillysiemens/layabout/
 .. _GitHub Flow: https://guides.github.com/introduction/flow/
+.. _pytest: https://docs.pytest.org/en/latest/
+.. _mypy: http://www.mypy-lang.org/
+.. _reStructuredText: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+.. _Sphinx: http://www.sphinx-doc.org/en/master/index.html

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,6 @@ clean-docs:  ## remove docs artifacts
 	$(MAKE) -C docs clean
 
 docs: clean-docs ## generate Sphinx HTML documentation, including API docs
-	rm -f docs/source/layabout.rst
-	rm -f docs/source/module.rst
-	sphinx-apidoc -f -o docs . setup.py
 	$(MAKE) -C docs html
 
 lint: ## check style with flake8

--- a/README.rst
+++ b/README.rst
@@ -13,85 +13,73 @@ Layabout
     :target: https://github.com/reillysiemens/layabout/blob/master/LICENSE
     :alt: ISC Licensed
 
-A small event handling library on top of the Slack RTM API.
+.. TODO Figure out what the Read the Docs URL should actually be.
 
-- Documentation: TODO
-- GitHub: https://github.com/reillysiemens/layabout
-- PyPi: TODO
+.. image:: https://img.shields.io/readthedocs/layabout/latest.svg?style=flat-square
+    :target: http://python-slackclient.readthedocs.io/en/latest/?badge=latest
+    :alt: Docs on Read the Docs
 
-What's in the Box?
-------------------
+.. image:: https://img.shields.io/pypi/v/layabout.svg?style=flat-square
+    :target: https://pypi.org/project/layabout
+    :alt: Layabout on PyPI
 
-- 🎉 The most fun you've had interacting with Slack in a while.
-- 🐍 Python 3.6+ support
-- 🆓 Free software: ISC License
+.. image:: https://img.shields.io/pypi/pyversions/layabout.svg?style=flat-square
+    :target: https://pypi.python.org/pypi/layabout
+    :alt: Python Version
 
-Features
---------
-
-- Automatically load Slack API tokens from environment variables or provide
-  them directly.
-- Register multiple event handlers for one event.
-- Register a single handler for multiple events by stacking decorators.
-- Configurable application shutdown.
-- Configurable retry logic in the event of lost connections.
-- Lightweight. Depends only on the official Python `slackclient`_ library.
-
-Installation
-------------
-
-.. code-block:: bash
-
-   pip install git+https://github.com/reillysiemens/layabout.git@master
-
-Quickstart
-----------
-
-Here's a quick example of an echo bot implemented with Layabout:
-
-.. code-block:: python
-
-   from layabout import Layabout
-
-   layabout = Layabout('app')
-
-
-   @layabout.handle('message')
-   def echo(slack, event):
-       """ Echo all messages seen by the app. """
-       channel = event['channel']
-       message = event['text']
-       subtype = event.get('subtype')
-
-       # Avoid an infinite loop of echoing our own messages.
-       if subtype != 'bot_message':
-           slack.rtm_send_message(channel, message)
-
-   layabout.run()
-
-Here's another example that uses Layabout to debug all Slack events seen by a
-bot until someone leaves a channel:
+**Layabout** is a small event handling library on top of the Slack RTM API.
 
 .. code-block:: python
 
    from pprint import pprint
    from layabout import Layabout
 
-   layabout = Layabout('app')
+   app = Layabout()
 
 
-   @layabout.handle('*')
+   @app.handle('*')
    def debug(slack, event):
        """ Pretty print every event seen by the app. """
        pprint(event)
 
 
+   @app.handle('message')
+   def echo(slack, event):
+       """ Echo all messages seen by the app except our own. """
+       if event.get('subtype') != 'bot_message':
+           slack.rtm_send_message(event['channel'], event['text'])
+
+
    def someone_leaves(events):
        """ Return False if a member leaves, otherwise True. """
-       return not any(e['type'] == 'member_left_channel' for e in events)
+       return not any(e.get('type') == 'member_left_channel'
+                      for e in events)
 
-   layabout.run(until=someone_leaves)
-   print('Looks like someone left a channel!')
+   if __name__ == '__main__':
+       app.run(until=someone_leaves)
+       print("Looks like someone left a channel!")
+
+Installation
+------------
+
+To install **Layabout** use `pip`_ and `PyPI`_:
+
+.. code-block:: bash
+
+   pip install layabout
+
+Features
+--------
+
+Not sold yet? Here's a list of features to sweeten the deal.
+
+- Automatically load Slack API tokens from environment variables, provide
+  them directly, or even bring your own SlackClient.
+- Register multiple event handlers for one event.
+- Register a single handler for multiple events by stacking decorators.
+- Configurable application shutdown.
+- Configurable retry logic in the event of lost connections.
+- Lightweight. Depends only on the official Python `slackclient`_ library.
 
 Code of Conduct
 ---------------
@@ -99,5 +87,7 @@ Code of Conduct
 Everyone interacting with the Layabout project's codebase is expected to follow
 the `Code of Conduct`_.
 
+.. _pip: https://pypi.org/project/pip/
+.. _PyPI: https://pypi.org/
 .. _slackclient: https://github.com/slackapi/python-slackclient
 .. _Code of Conduct: https://github.com/reillysiemens/layabout/blob/master/CODE_OF_CONDUCT.rst

--- a/README.rst
+++ b/README.rst
@@ -19,13 +19,13 @@ Layabout
     :target: http://python-slackclient.readthedocs.io/en/latest/?badge=latest
     :alt: Docs on Read the Docs
 
+.. image:: https://img.shields.io/pypi/pyversions/layabout.svg?style=flat-square&label=python
+    :target: https://pypi.python.org/pypi/layabout
+    :alt: Python Version
+
 .. image:: https://img.shields.io/pypi/v/layabout.svg?style=flat-square
     :target: https://pypi.org/project/layabout
     :alt: Layabout on PyPI
-
-.. image:: https://img.shields.io/pypi/pyversions/layabout.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/layabout
-    :alt: Python Version
 
 **Layabout** is a small event handling library on top of the Slack RTM API.
 

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,6 @@ Layabout
     :target: https://github.com/reillysiemens/layabout/blob/master/LICENSE
     :alt: ISC Licensed
 
-.. TODO Figure out what the Read the Docs URL should actually be.
-
 .. image:: https://img.shields.io/readthedocs/layabout/latest.svg?style=flat-square
     :target: http://python-slackclient.readthedocs.io/en/latest/?badge=latest
     :alt: Docs on Read the Docs
@@ -56,6 +54,7 @@ Layabout
                       for e in events)
 
    if __name__ == '__main__':
+       # Automatically load app token from $SLACK_API_TOKEN and run!
        app.run(until=someone_leaves)
        print("Looks like someone left a channel!")
 

--- a/docs/_templates/sidebar.html
+++ b/docs/_templates/sidebar.html
@@ -1,0 +1,1 @@
+<p>Layabout is a small event handling library on top of the Slack RTM API.</p>

--- a/docs/_templates/useful-links.html
+++ b/docs/_templates/useful-links.html
@@ -1,0 +1,6 @@
+<h3>Useful Links</h3>
+<ul>
+  {% for text, uri in theme_extra_nav_links.items() %}
+    <li><a href="{{uri}}">{{text}}</a></li>
+  {% endfor %}
+</ul>

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,5 @@
+.. _api:
+
 API Reference
 =============
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,35 @@
+API Reference
+=============
+
+.. module:: layabout
+
+Layabout
+--------
+
+.. autoclass:: layabout.Layabout
+   :members:
+
+Connectors
+----------
+
+In addition to a :obj:`slackclient.SlackClient` these classes may be
+passed as a ``connector`` to :meth:`Layabout.run`.
+
+.. autoclass:: layabout.EnvVar
+   :show-inheritance:
+
+.. autoclass:: layabout.Token
+   :show-inheritance:
+
+
+Exceptions
+----------
+
+.. autoexception:: layabout.LayaboutError
+   :show-inheritance:
+
+.. autoexception:: layabout.MissingSlackToken
+   :show-inheritance:
+
+.. autoexception:: layabout.FailedConnection
+   :show-inheritance:

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,0 +1,1 @@
+.. include:: ../AUTHORS.rst

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.rst

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,3 @@
+.. _changelog:
+
 .. include:: ../CHANGELOG.rst

--- a/docs/code_of_conduct.rst
+++ b/docs/code_of_conduct.rst
@@ -1,0 +1,1 @@
+.. include:: ../CODE_OF_CONDUCT.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ extensions = [
 
 intersphinx_mapping = {
     'python': ('http://python.readthedocs.io/en/latest/', None),
+    'slackclient': ('https://python-slackclient.readthedocs.io/en/latest/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,8 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output -------------------------------------------------
 
+html_show_sourcelink = False
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
@@ -119,58 +121,6 @@ html_static_path = ['_static']
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'layaboutdoc'
-
-
-# -- Options for LaTeX output ------------------------------------------------
-
-latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
-
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
-
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
-
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
-}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'layabout.tex', 'layabout Documentation',
-     'Reilly Tucker Siemens', 'manual'),
-]
-
-
-# -- Options for manual page output ------------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'layabout', 'layabout Documentation',
-     [author], 1)
-]
-
-
-# -- Options for Texinfo output ----------------------------------------------
-
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
-texinfo_documents = [
-    (master_doc, 'layabout', 'layabout Documentation',
-     author, 'layabout', 'One line description of project.',
-     'Miscellaneous'),
-]
-
 
 # -- Extension configuration -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 
 import sys
 import datetime as dt
+from collections import OrderedDict
 from pathlib import Path
 sys.path.insert(0, str(Path('..').resolve()))
 
@@ -99,7 +100,19 @@ html_theme = 'alabaster'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'github_user': 'reillysiemens',
+    'github_repo': 'layabout',
+    'github_type': 'star',
+    'note_bg': '#FFF59C',
+    # Used to populate the useful-links.html template.
+    'extra_nav_links': OrderedDict([
+        ('Layabout @ PyPI', 'https://pypi.org/project/layabout/'),
+        ('Layabout @ GitHub', 'https://github.com/reillysiemens/layabout/'),
+        ('Issue Tracker', 'https://github.com/reillysiemens/layabout/issues/'),
+        ('Slack RTM API Docs', 'https://api.slack.com/rtm'),
+    ]),
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -114,7 +127,15 @@ html_static_path = ['_static']
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
-# html_sidebars = {}
+html_sidebars = {
+    'index': [
+        'about.html', 'sidebar.html', 'useful-links.html', 'searchbox.html',
+    ],
+    '**': [
+        'about.html', 'sidebar.html', 'useful-links.html', 'localtoc.html',
+        'relations.html', 'searchbox.html',
+    ],
+}
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,6 @@ extensions = [
 
 intersphinx_mapping = {
     'python': ('http://python.readthedocs.io/en/latest/', None),
-    'slackclient': ('https://python-slackclient.readthedocs.io/en/latest/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,1 @@
+.. include:: ../CONTRIBUTING.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,18 +1,110 @@
-.. layabout documentation master file, created by
-   sphinx-quickstart on Wed Feb 14 00:57:05 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. layabout documentation master file
 
-Welcome to layabout's documentation!
-====================================
+Layabout
+========
 
 Release v\ |release|.
 
+.. image:: https://img.shields.io/travis/reillysiemens/layabout/master.svg?style=flat-square&label=build
+    :target: https://travis-ci.org/reillysiemens/layabout
+    :alt: Unix build status on Travis CI
+
+.. image:: https://img.shields.io/coveralls/reillysiemens/layabout/master.svg?style=flat-square&label=coverage
+    :target: https://coveralls.io/github/reillysiemens/layabout?branch=master
+    :alt: Code coverage on Coveralls
+
+.. image:: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
+    :target: https://github.com/reillysiemens/layabout/blob/master/LICENSE
+    :alt: ISC Licensed
+
+.. TODO Figure out what the Read the Docs URL should actually be.
+
+.. image:: https://img.shields.io/readthedocs/layabout/latest.svg?style=flat-square
+    :target: http://python-slackclient.readthedocs.io/en/latest/?badge=latest
+    :alt: Docs on Read the Docs
+
+.. image:: https://img.shields.io/pypi/v/layabout.svg?style=flat-square
+    :target: https://pypi.org/project/layabout
+    :alt: Layabout on PyPI
+
+.. image:: https://img.shields.io/pypi/pyversions/layabout.svg?style=flat-square
+    :target: https://pypi.python.org/pypi/layabout
+    :alt: Python Version
+
+**Layabout** is a small event handling library on top of the Slack RTM API.
+
+.. code-block:: python
+
+   from pprint import pprint
+   from layabout import Layabout
+
+   app = Layabout()
+
+
+   @app.handle('*')
+   def debug(slack, event):
+       """ Pretty print every event seen by the app. """
+       pprint(event)
+
+
+   @app.handle('message')
+   def echo(slack, event):
+       """ Echo all messages seen by the app except our own. """
+       if event.get('subtype') != 'bot_message':
+           slack.rtm_send_message(event['channel'], event['text'])
+
+
+   def someone_leaves(events):
+       """ Return False if a member leaves, otherwise True. """
+       return not any(e.get('type') == 'member_left_channel'
+                      for e in events)
+
+   if __name__ == '__main__':
+       app.run(until=someone_leaves)
+       print("Looks like someone left a channel!")
+
+Installation
+------------
+
+To install **Layabout** use `pip`_ and `PyPI`_:
+
+.. code-block:: bash
+
+   pip install layabout
+
+Features
+--------
+
+Not sold yet? Here's a list of features to sweeten the deal.
+
+- Automatically load Slack API tokens from environment variables, provide
+  them directly, or even bring your own :obj:`SlackClient`.
+- Register multiple event handlers for one event.
+- Register a single handler for multiple events by stacking decorators.
+- Configurable application shutdown.
+- Configurable retry logic in the event of lost connections.
+- Lightweight. Depends only on the official Python `slackclient`_ library.
+
+.. note::
+
+   Layabout **only** supports Python 3.6+ and will never be backported to
+   Python 2. If you haven't moved over to Python 3 yet please consider the
+   `many reasons to do so <http://www.asmeurer.com/python3-presentation/slides.html>`_.
+
+Project Info
+------------
+
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :maxdepth: 1
 
+   why
+   changelog
+   license
+   authors
+   contributing
+   code_of_conduct
 
+.. TODO remove this and add API docs
 
 Indices and tables
 ==================
@@ -20,3 +112,7 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+.. _pip: https://pypi.org/project/pip/
+.. _PyPI: https://pypi.org/
+.. _slackclient: https://pypi.org/project/slackclient/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
 Layabout
 ========
 
-Release v\ |release|.
+Release v\ |release|. (:ref:`Changelog <changelog>`)
 
 .. image:: https://img.shields.io/travis/reillysiemens/layabout/master.svg?style=flat-square&label=build
     :target: https://travis-ci.org/reillysiemens/layabout
@@ -16,8 +16,6 @@ Release v\ |release|.
 .. image:: https://img.shields.io/badge/license-ISC-blue.svg?style=flat-square
     :target: https://github.com/reillysiemens/layabout/blob/master/LICENSE
     :alt: ISC Licensed
-
-.. TODO Figure out what the Read the Docs URL should actually be.
 
 .. image:: https://img.shields.io/readthedocs/layabout/latest.svg?style=flat-square
     :target: http://python-slackclient.readthedocs.io/en/latest/?badge=latest
@@ -60,6 +58,7 @@ Release v\ |release|.
                       for e in events)
 
    if __name__ == '__main__':
+       # Automatically load app token from $SLACK_API_TOKEN and run!
        app.run(until=someone_leaves)
        print("Looks like someone left a channel!")
 
@@ -85,12 +84,6 @@ Not sold yet? Here's a list of features to sweeten the deal.
 - Configurable retry logic in the event of lost connections.
 - Lightweight. Depends only on the official Python `slackclient`_ library.
 
-.. note::
-
-   Layabout **only** supports Python 3.6+ and will never be backported to
-   Python 2. If you haven't moved over to Python 3 yet please consider the
-   `many reasons to do so <http://www.asmeurer.com/python3-presentation/slides.html>`_.
-
 API Reference
 -------------
 
@@ -111,6 +104,12 @@ Project Info
    authors
    contributing
    code_of_conduct
+
+.. note::
+
+   Layabout **only** supports Python 3.6+ and will never be backported to
+   Python 2. If you haven't moved over to Python 3 yet please consider the
+   `many reasons to do so <http://www.asmeurer.com/python3-presentation/slides.html>`_.
 
 .. _pip: https://pypi.org/project/pip/
 .. _PyPI: https://pypi.org/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,13 +23,13 @@ Release v\ |release|.
     :target: http://python-slackclient.readthedocs.io/en/latest/?badge=latest
     :alt: Docs on Read the Docs
 
+.. image:: https://img.shields.io/pypi/pyversions/layabout.svg?style=flat-square&label=python
+    :target: https://pypi.python.org/pypi/layabout
+    :alt: Python Version
+
 .. image:: https://img.shields.io/pypi/v/layabout.svg?style=flat-square
     :target: https://pypi.org/project/layabout
     :alt: Layabout on PyPI
-
-.. image:: https://img.shields.io/pypi/pyversions/layabout.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/layabout
-    :alt: Python Version
 
 **Layabout** is a small event handling library on top of the Slack RTM API.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,6 +91,14 @@ Not sold yet? Here's a list of features to sweeten the deal.
    Python 2. If you haven't moved over to Python 3 yet please consider the
    `many reasons to do so <http://www.asmeurer.com/python3-presentation/slides.html>`_.
 
+API Reference
+-------------
+
+.. toctree::
+   :maxdepth: 2
+
+   api
+
 Project Info
 ------------
 
@@ -103,15 +111,6 @@ Project Info
    authors
    contributing
    code_of_conduct
-
-.. TODO remove this and add API docs
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
 
 .. _pip: https://pypi.org/project/pip/
 .. _PyPI: https://pypi.org/

--- a/docs/layabout.rst
+++ b/docs/layabout.rst
@@ -1,7 +1,0 @@
-layabout module
-===============
-
-.. automodule:: layabout
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,4 @@
+License
+=======
+
+.. include:: ../LICENSE

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-layabout
-========
-
-.. toctree::
-   :maxdepth: 4
-
-   layabout

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -1,0 +1,21 @@
+Why Layabout?
+=============
+
+Why Layabout when the Slack `Events API`_ exists and there's already an
+officially supported `events library`_?
+
+Simply put, if you don't want to run a web server so Slack can call you when
+events happen, then Layabout is for you.
+
+Most `events`_ are supported by the Slack `RTM API`_ as well and Layabout
+enables you to start handling events quickly without worrying about setting up
+Flask, configuring a reverse proxy, acquiring an SSL certificate, and the
+myriad other tasks that come with hosting a web app.
+
+That said, if you can't afford to have a persistent WebSocket connection to the
+Slack API, then you probably *do* want to use the official `events library`_.
+
+.. _Events API: https://api.slack.com/events-api
+.. _events library: https://github.com/slackapi/python-slack-events-api
+.. _events: https://api.slack.com/events
+.. _RTM API: https://api.slack.com/rtm

--- a/layabout.py
+++ b/layabout.py
@@ -21,7 +21,7 @@ from slackclient import SlackClient
 
 __author__ = 'Reilly Tucker Siemens'
 __email__ = 'reilly@tuckersiemens.com'
-__version__ = '1.0.0b'
+__version__ = '1.0.0b1'
 
 # Private type alias for the complex type of the handlers defaultdict.
 _Handlers = DefaultDict[str, List[Tuple[Callable, dict]]]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+  image: latest
+
+python:
+  version: 3.6

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,3 +3,6 @@ build:
 
 python:
   version: 3.6
+  pip_install: true
+  extra_requirements:
+    - dev


### PR DESCRIPTION
The resulting docs are currently rendered at [Read the Docs](https://layabout.readthedocs.io/en/docs).