### PR TITLE
Add finishing touches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,19 @@ tag-release: check-origin-remote
 	git tag -a $(VERSION) -m "Release $(VERSION)"
 	git push origin $(VERSION)
 
-release: dist tag-release ## package and upload for public release
-	gpg --detach-sign -a dist/layabout-*.tar.gz
-	twine upload dist/*
+sign-artifacts:
+	# This doesn't have help text because it's intended to be a release helper.
+	# Apparently gpg isn't good with batching detached signatures...
+	# https://lists.gnupg.org/pipermail/gnupg-users/2002-August/014602.html
+	for artifact in dist/*; do \
+		gpg2 --detach-sign -a $$artifact; \
+	done
 
 dist: clean ## build source and wheel packages
 	python3 setup.py sdist bdist_wheel
+
+release: dist sign-artifacts tag-release ## package and upload for public release
+	twine upload dist/*
 
 install: clean ## install the package into the active Python's site-packages
 	python3 setup.py install

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Layabout
                       for e in events)
 
    if __name__ == '__main__':
-       # Automatically load app token from $SLACK_API_TOKEN and run!
+       # Automatically load app token from $LAYABOUT_TOKEN and run!
        app.run(until=someone_leaves)
        print("Looks like someone left a channel!")
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ Release v\ |release|. (:ref:`Changelog <changelog>`)
                       for e in events)
 
    if __name__ == '__main__':
-       # Automatically load app token from $SLACK_API_TOKEN and run!
+       # Automatically load app token from $LAYABOUT_TOKEN and run!
        app.run(until=someone_leaves)
        print("Looks like someone left a channel!")
 

--- a/examples/simple/example.py
+++ b/examples/simple/example.py
@@ -11,7 +11,7 @@ def print_all(slack, event):
 
 
 # We don't need to pass anything to run. By default the API token will
-# be fetched from the LAYABOUT_API_TOKEN environment variable.
+# be fetched from the LAYABOUT_TOKEN environment variable.
 if __name__ == "__main__":
     print('Printing all events. Press Ctrl-C to quit.\n')
     app.run()

--- a/layabout.py
+++ b/layabout.py
@@ -141,32 +141,6 @@ class Layabout:
         self._slack: Optional[_SlackClientWrapper] = None
         self._handlers: _Handlers = defaultdict(list)
 
-    @staticmethod
-    def _format_parameter_error_message(name: str, sig: Signature,
-                                        num_params: int) -> str:
-        """
-        Format an error message for missing positional arguments.
-
-        Args:
-            name: The function name.
-            sig: The function's signature.
-            num_params: The number of function parameters.
-
-        Returns:
-            str: A formatted error message.
-        """
-        if num_params == 0:
-            plural = 's'
-            missing = 2
-            arguments = "'slack' and 'event'"
-        else:
-            plural = ''
-            missing = 1
-            arguments = "'event'"
-
-        return (f"{name}{sig} missing {missing} required positional "
-                f"argument{plural}: {arguments}")
-
     def handle(self, type: str, *, kwargs: dict = None) -> Callable:
         """
         Register an event handler with the :obj:`Layabout` instance.
@@ -192,7 +166,7 @@ class Layabout:
             sig = signature(fn)
             num_params = len(sig.parameters)
             if num_params < 2:
-                raise TypeError(self._format_parameter_error_message(
+                raise TypeError(_format_parameter_error_message(
                     fn.__name__, sig, num_params))
 
             # Register a tuple of the callable and its kwargs, if any.
@@ -280,6 +254,32 @@ class Layabout:
 
             # Maybe don't pester the Slack API too much.
             time.sleep(interval)
+
+
+def _format_parameter_error_message(name: str, sig: Signature,
+                                    num_params: int) -> str:
+    """
+    Format an error message for missing positional arguments.
+
+    Args:
+        name: The function name.
+        sig: The function's signature.
+        num_params: The number of function parameters.
+
+    Returns:
+        str: A formatted error message.
+    """
+    if num_params == 0:
+        plural = 's'
+        missing = 2
+        arguments = "'slack' and 'event'"
+    else:
+        plural = ''
+        missing = 1
+        arguments = "'event'"
+
+    return (f"{name}{sig} missing {missing} required positional "
+            f"argument{plural}: {arguments}")
 
 
 @singledispatch

--- a/layabout.py
+++ b/layabout.py
@@ -137,7 +137,7 @@ class Layabout:
            app.run()
     """
     def __init__(self) -> None:
-        self._env_var = EnvVar('SLACK_API_TOKEN')
+        self._env_var = EnvVar('LAYABOUT_TOKEN')
         self._slack: Optional[_SlackClientWrapper] = None
         self._handlers: _Handlers = defaultdict(list)
 
@@ -230,7 +230,7 @@ class Layabout:
             connector: A means of connecting to the Slack API. This can be an
                 API :obj:`Token`, an :obj:`EnvVar` from which a token can be
                 retrieved, or an established :obj:`SlackClient` instance. If
-                absent an attempt will be made to use the ``SLACK_API_TOKEN``
+                absent an attempt will be made to use the ``LAYABOUT_TOKEN``
                 environment variable.
             interval: The number of seconds to wait between fetching events
                 from the Slack API.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=install_reqs,
     license='ISCL',
     py_modules=['layabout'],
-    keywords='Slack RTM API',
+    keywords='Slack RTM API Bot Framework',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -216,7 +216,7 @@ def test_layabout_can_connect_to_slack_with_env_var(monkeypatch):
     Test that layabout can discover and use a Slack API token from an
     environment variable when not given one directly.
     """
-    env_var = EnvVar('_TEST_SLACK_API_TOKEN')
+    env_var = EnvVar('_TEST_LAYABOUT_TOKEN')
     environ = {env_var: TOKEN}
     layabout = Layabout()
     SlackClient, slack = mock_slack(connections=(True,))
@@ -266,7 +266,7 @@ def test_layabout_raises_missing_slack_token_without_token(monkeypatch):
         # until will exit early here just to be safe.
         layabout.run(until=lambda e: False)
 
-    assert str(exc.value) == 'Could not acquire token from SLACK_API_TOKEN'
+    assert str(exc.value) == 'Could not acquire token from LAYABOUT_TOKEN'
 
 
 def test_layabout_raises_missing_slack_token_with_empty_token():


### PR DESCRIPTION
This PR changes `SLACK_API_TOKEN` to `LAYABOUT_TOKEN` and moves the parameter error formatter from being a `@staticmethod` to just a normal function.