### PR TITLE
Rename MissingSlackToken to MissingToken

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,7 +30,7 @@ Exceptions
 .. autoexception:: layabout.LayaboutError
    :show-inheritance:
 
-.. autoexception:: layabout.MissingSlackToken
+.. autoexception:: layabout.MissingToken
    :show-inheritance:
 
 .. autoexception:: layabout.FailedConnection

--- a/layabout.py
+++ b/layabout.py
@@ -33,7 +33,7 @@ class LayaboutError(Exception):
     """ Base error for all Layabout exceptions. """
 
 
-class MissingSlackToken(LayaboutError):
+class MissingToken(LayaboutError):
     """ Raised if a Slack API token could not be found. """
 
 
@@ -222,7 +222,7 @@ class Layabout:
 
         Raises:
             TypeError: If an unsupported connector is given.
-            MissingSlackToken: If no API token is available.
+            MissingToken: If no API token is available.
             FailedConnection: If connecting to the Slack API fails.
 
         .. _truncated exponential backoff:
@@ -300,7 +300,7 @@ def _create_slack_with_env_var(env_var: EnvVar) -> SlackClient:
     token = os.getenv(env_var)
     if token:
         return SlackClient(token=token)
-    raise MissingSlackToken(f"Could not acquire token from {env_var}")
+    raise MissingToken(f"Could not acquire token from {env_var}")
 
 
 @_create_slack.register(Token)
@@ -308,7 +308,7 @@ def _create_slack_with_token(token: Token) -> SlackClient:
     """ Create a :obj:`SlackClient` with a provided token. """
     if token != Token(''):
         return SlackClient(token=token)
-    raise MissingSlackToken("The empty string is an invalid Slack API token")
+    raise MissingToken("The empty string is an invalid Slack API token")
 
 
 @_create_slack.register(SlackClient)

--- a/tests/test_layabout.py
+++ b/tests/test_layabout.py
@@ -9,7 +9,7 @@ from layabout import (
     EnvVar,
     FailedConnection,
     Layabout,
-    MissingSlackToken,
+    MissingToken,
     Token,
     _SlackClientWrapper,
     _truncated_exponential,
@@ -252,31 +252,30 @@ def test_layabout_raises_type_error_with_string_connector():
                               'instead of str')
 
 
-def test_layabout_raises_missing_slack_token_without_token(monkeypatch):
+def test_layabout_raises_missing_token_without_token(monkeypatch):
     """
-    Test that layabout raises a MissingSlackToken if there is no Slack API
-    token for it to use.
+    Test that layabout raises a MissingToken if there is no Slack API token for
+    it to use.
     """
     environ = dict()
     layabout = Layabout()
 
     monkeypatch.setattr(os, 'environ', environ)
 
-    with pytest.raises(MissingSlackToken) as exc:
+    with pytest.raises(MissingToken) as exc:
         # until will exit early here just to be safe.
         layabout.run(until=lambda e: False)
 
     assert str(exc.value) == 'Could not acquire token from LAYABOUT_TOKEN'
 
 
-def test_layabout_raises_missing_slack_token_with_empty_token():
+def test_layabout_raises_missing_token_with_empty_token():
     """
-    Test that layabout raises a MissingSlackToken if given an empty Slack API
-    token.
+    Test that layabout raises a MissingToken if given an empty Slack API token.
     """
     layabout = Layabout()
 
-    with pytest.raises(MissingSlackToken) as exc:
+    with pytest.raises(MissingToken) as exc:
         # until will exit early here just to be safe.
         layabout.run(connector=Token(''), until=lambda e: False)
 


### PR DESCRIPTION
This PR renames the `MissingSlackToken` exception to `MissingToken` for the sake of simplicity since all Layabout tokens are intended to be used with Slack.