### PR TITLE
Handle cases where API token is not present [23]

### DIFF
--- a/examples/conditional-exit/example.py
+++ b/examples/conditional-exit/example.py
@@ -1,4 +1,6 @@
-from layabout import Layabout
+import sys
+
+from layabout import Layabout, MissingToken
 
 app = Layabout()
 
@@ -21,7 +23,13 @@ def main():
         return True
 
     # This will run only until someone enters the magic word(s) into a channel.
-    app.run(until=someone_says_the_magic_word)
+    try:
+      app.run(until=someone_says_the_magic_word)
+    except MissingToken:
+      sys.exit('Unable to find Slack API token.\n'
+               'Learn more about available token types here:\n'
+               'https://api.slack.com/docs/token-types.')
+
     print(f'Someone said "{magic}"!')
 
 

--- a/examples/early-connection/example.py
+++ b/examples/early-connection/example.py
@@ -43,7 +43,9 @@ def main():
     token = os.getenv(env_var)
 
     if not token:
-        sys.exit(f"Couldn't load ${env_var}. Try setting it.")
+        sys.exit(f"Couldn't load ${env_var}. Try setting it.\n"
+                  "Learn more about available token types here:\n"
+                  "https://api.slack.com/docs/token-types.")
 
     slack = SlackClient(token=token)
 
@@ -53,7 +55,7 @@ def main():
     # Send a message to some channel before running the event loop!
     send_message(slack)
 
-    print('Listening for typing events. Press Ctrl-C to quit.\n')
+    print('Listening for typing events. Press Ctrl-C to quit.')
     # Now run the loop. This will re-use the existing SlackClient connection!
     app.run(connector=slack)
 

--- a/examples/runtime-handler-definition/example.py
+++ b/examples/runtime-handler-definition/example.py
@@ -1,6 +1,8 @@
+import sys
+
 from pprint import pformat
 
-from layabout import Layabout
+from layabout import Layabout, MissingToken
 
 app = Layabout()
 
@@ -31,8 +33,12 @@ def main():
         debug_channel = channel_to_id(slack, channel_name)
         if event.get('channel') == debug_channel:
             print(f"Got event in #{channel_name}:\n{pformat(event)}\n")
-
-    app.run()
+    try:
+      app.run()
+    except MissingToken:
+      sys.exit('Unable to find Slack API token.\n'
+               'Learn more about available token types here:\n'
+               'https://api.slack.com/docs/token-types.')
 
 
 if __name__ == '__main__':

--- a/examples/simple/example.py
+++ b/examples/simple/example.py
@@ -1,5 +1,7 @@
+import  sys
+
 from pprint import pformat
-from layabout import Layabout
+from layabout import Layabout, MissingToken
 
 app = Layabout()
 
@@ -13,5 +15,11 @@ def print_all(slack, event):
 # We don't need to pass anything to run. By default the API token will
 # be fetched from the LAYABOUT_TOKEN environment variable.
 if __name__ == "__main__":
-    print('Printing all events. Press Ctrl-C to quit.\n')
-    app.run()
+    print('Printing all events. Press Ctrl-C to quit.')
+
+    try:
+      app.run()
+    except MissingToken:
+      sys.exit('Unable to find Slack API token.\n'
+            'Learn more about available token types here:\n'
+            'https://api.slack.com/docs/token-types.')


### PR DESCRIPTION
Resolve #23 by adding `try`/`except` blocks where `app.run` is called in the `layabout` examples. The exception where there is no Slack API token is handled more gracefully and provides information about where to get a token.