### PR TITLE
Add Python 3.7 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: python
-python:
-  - "3.6"
+matrix:
+  include:
+    - python: 3.6
+      dist: trusty
+      sudo: false
+    - python: 3.7
+      dist: xenial
+      sudo: true
 env:
   global:
-    - NEWEST_PYTHON=3.6
+    - NEWEST_PYTHON=3.7
 install:
   - pip install -e .'[test]'
 script:


### PR DESCRIPTION
Resolve #20 by adding a `matrix.include` in `.travis.yml` and setting `dist: xenial` and `sudo: true` for Python 3.7 according to the [latest instructions from Travis CI](https://github.com/travis-ci/travis-ci/issues/9815#issuecomment-401756442)