### PR TITLE
Support Python 3.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,15 +9,29 @@ of `keepachangelog.com <http://keepachangelog.com/>`_.
 Unreleased_
 -----------
 
-.. _Unreleased: https://github.com/reillysiemens/layabout/compare/v1.0.0...HEAD
+.. _Unreleased: https://github.com/reillysiemens/layabout/compare/v1.0.1...HEAD
 
+`v1.0.1 (2018-10-14)`__
+-----------------------
+
+Added
+~~~~~
+- Official support for Python 3.7.
+
+Changed
+~~~~~~~
+- Improve the examples to warn users when an API token is missing.
+- Improve the format of ``CHANGELOG.rst``.
 
 `v1.0.0 (2018-06-18)`__
----------------------------
+-----------------------
 
 Initial release.
 
-.. _v1.0.0: https://github.com/reillysiemens/layabout/compare/d545cec...v1.0.0 
+.. _v1.0.1: https://github.com/reillysiemens/layabout/compare/v1.0.0...v1.0.1
+__ v1.0.1_
+
+.. _v1.0.0: https://github.com/reillysiemens/layabout/compare/d545cec...v1.0.0
 __ v1.0.0_
 
 Contributors
@@ -25,4 +39,5 @@ Contributors
 
 - Geoff Shannon (`@RadicalZephyr <https://github.com/RadicalZephyr>`_)
 - Mike Canoy (`@solus-impar <https://github.com/solus-impar>`_)
+- Sophie Anderson (`@SophieKAn <https://github.com/SophieKAn>`_)
 - Tucker Siemens (`@reillysiemens <https://github.com/reillysiemens>`_)

--- a/layabout.py
+++ b/layabout.py
@@ -20,7 +20,7 @@ from slackclient import SlackClient
 
 __author__ = 'Reilly Tucker Siemens'
 __email__ = 'reilly@tuckersiemens.com'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 # Private type alias for the complex type of the handlers defaultdict.
 _Handlers = DefaultDict[str, List[Tuple[Callable, dict]]]

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Operating System :: POSIX :: BSD :: FreeBSD',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Communications :: Chat',


### PR DESCRIPTION
This PR tweaks the [trove classifiers](https://pypi.org/classifiers/) in `setup.py` so that PyPI will become aware of the support for Python 3.7. Travis CI has a functioning (albeit hacky) way to support CI for Python 3.7 and I now have a local development environment. With those two things in place I'm comfortable declaring official support.

It also updates `CHANGELOG.rst` with some unrelated changes because I was behind on keeping it up-to-date... :sweat_smile: