### PR TITLE
Add a pyproject.toml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,18 @@ matrix:
 env:
   global:
     - NEWEST_PYTHON=3.7
+before_install:
+  - pip install poetry
 install:
-  - pip install -e .'[test]'
+  - poetry install
 script:
   - make lint
   - make type-check
   - make test
-after_success:         
-  - |                  
-    if [[ $TRAVIS_PYTHON_VERSION == $NEWEST_PYTHON ]]; then                                    
-      pip install python-coveralls && coveralls                                                
-    fi                 
-notifications:         
+after_success:
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == $NEWEST_PYTHON ]]; then
+      pip install python-coveralls && coveralls
+    fi
+notifications:
   email: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[tool.poetry]
+name = "layabout"
+version = "1.0.1"
+description = "A small event handling library on top of the Slack RTM API."
+authors = ["Reilly Tucker Siemens <reilly@tuckersiemens.com>"]
+license = "ISC"
+readme = "README.rst"
+repository = "https://github.com/reillysiemens/layabout"
+keywords = ["Slack", "RTM", "API", "Bot", "Framework"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: ISC License (ISCL)",
+    "Natural Language :: English",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: POSIX :: BSD :: FreeBSD",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Communications :: Chat",
+    "Topic :: Software Development :: Libraries",
+]
+include = ["LICENSE"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+slackclient = "^1.2"
+
+[tool.poetry.dev-dependencies]
+mypy = "^0.740.0"
+flake8 = "^3.7.8"
+pytest = "^5.2"
+pytest-cov = "^2.8"
+sphinx = "^2.2"
+sphinx-autodoc-typehints = "^1.8"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Resolves #6 

Added a `pyproject.toml` file with roughly the same information as the current `setup.py`. I haven't removed any other package-management related files, but with full adoption of `poetry`, they can eventually be removed. I did not include the generated `poetry.lock` file either, because things may still need to be tweaked to get an official version.

# Testing
Running with existing dependencies already installed:
```
$ poetry install
Updating dependencies
Resolving dependencies... (1.4s)

Writing lock file

Nothing to install or update

  - Installing layabout (1.0.1)
```