### PR TITLE
Deprecate Layabout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
+    - python: 3.8
+      dist: xenial
+      sudo: true
 env:
   global:
     - NEWEST_PYTHON=3.7

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,19 @@ of `keepachangelog.com <http://keepachangelog.com/>`_.
 Unreleased_
 -----------
 
-.. _Unreleased: https://github.com/reillysiemens/layabout/compare/v1.0.1...HEAD
+.. _Unreleased: https://github.com/reillysiemens/layabout/compare/v1.0.2...HEAD
+
+`v1.0.2 (2020-01-11)`__
+------------------------
+
+Added
+~~~~~
+- Mention of Python 3.8 functionality.
+- Information about how to acquire Slack API tokens in examples.
+
+Deprecated
+~~~~~~~~~~
+- Layabout is `deprecated`_. There will be no further support.
 
 `v1.0.1 (2018-10-14)`__
 -----------------------
@@ -28,6 +40,9 @@ Changed
 
 Initial release.
 
+.. _v1.0.2: https://github.com/reillysiemens/layabout/compare/v1.0.1...v1.0.2
+__ v1.0.2_
+
 .. _v1.0.1: https://github.com/reillysiemens/layabout/compare/v1.0.0...v1.0.1
 __ v1.0.1_
 
@@ -41,3 +56,5 @@ Contributors
 - Mike Canoy (`@solus-impar <https://github.com/solus-impar>`_)
 - Sophie Anderson (`@SophieKAn <https://github.com/SophieKAn>`_)
 - Tucker Siemens (`@reillysiemens <https://github.com/reillysiemens>`_)
+
+.. _deprecated: https://layabout.readthedocs.io/en/latest/deprecation.html

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,9 @@ Layabout
     :target: https://pypi.org/project/layabout
     :alt: Layabout on PyPI
 
+⚠️ Layabout is `deprecated`_. There will be no further support. ⚠️
+=================================================================
+
 **Layabout** is a small event handling library on top of the Slack RTM API.
 
 .. code-block:: python
@@ -95,6 +98,7 @@ Code of Conduct
 Everyone interacting with the Layabout project's codebase is expected to follow
 the `Code of Conduct`_.
 
+.. _deprecated: https://layabout.readthedocs.io/en/latest/deprecation.html
 .. _pip: https://pypi.org/project/pip/
 .. _PyPI: https://pypi.org/
 .. _examples: https://github.com/reillysiemens/layabout/tree/master/examples

--- a/docs/deprecation.rst
+++ b/docs/deprecation.rst
@@ -1,0 +1,22 @@
+Deprecation
+===========
+
+Layabout is deprecated as of **January 1st, 2020**.
+
+What?
+-----
+
+There will be no further support for Layabout, **even for security issues**.
+Layabout will likely continue to work as long as as the ``1.x`` family of the
+`slackclient`_ library functions, but it is **strongly** recommended that you
+migrate to the ``2.x`` family of `slackclient`_.
+
+Why?
+----
+
+Please read the associated `blog post`_ that details the rationale for
+deprecation. **TL;DR**: The ``2.x`` family of the official `slackclient`_
+library includes updates that make Layabout obsolete.
+
+.. _slackclient: https://pypi.org/project/slackclient/
+.. _blog post: https://tuckersiemens.com/posts/deprecating-layabout/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,10 @@ Release v\ |release|. (:ref:`Changelog <changelog>`)
     :target: https://pypi.org/project/layabout
     :alt: Layabout on PyPI
 
+.. warning::
+
+   Layabout is `deprecated`_. There will be no further support.
+
 **Layabout** is a small event handling library on top of the Slack RTM API.
 
 .. code-block:: python
@@ -107,6 +111,7 @@ Project Info
 .. toctree::
    :maxdepth: 1
 
+   deprecation
    why
    changelog
    license
@@ -120,6 +125,7 @@ Project Info
    Python 2. If you haven't moved over to Python 3 yet please consider the
    `many reasons to do so <http://www.asmeurer.com/python3-presentation/slides.html>`_.
 
+.. _deprecated: deprecation.html
 .. _pip: https://pypi.org/project/pip/
 .. _PyPI: https://pypi.org/
 .. _examples: https://github.com/reillysiemens/layabout/tree/master/examples

--- a/layabout.py
+++ b/layabout.py
@@ -2,6 +2,7 @@ import os
 import time
 import random
 import logging
+import warnings
 from typing import (
     Any,
     Callable,
@@ -17,6 +18,16 @@ from functools import singledispatch
 from collections import defaultdict
 
 from slackclient import SlackClient
+
+warnings.warn(
+    (
+        "Layabout is deprecated. See "
+        "https://layabout.readthedocs.io/en/latest/deprecation.html "
+        "for more information."
+    ),
+    category=DeprecationWarning,
+    stacklevel=2,
+)
 
 __author__ = 'Reilly Tucker Siemens'
 __email__ = 'reilly@tuckersiemens.com'

--- a/layabout.py
+++ b/layabout.py
@@ -31,7 +31,7 @@ warnings.warn(
 
 __author__ = 'Reilly Tucker Siemens'
 __email__ = 'reilly@tuckersiemens.com'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 # Private type alias for the complex type of the handlers defaultdict.
 _Handlers = DefaultDict[str, List[Tuple[Callable, dict]]]

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'Operating System :: POSIX :: BSD :: FreeBSD',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Communications :: Chat',


### PR DESCRIPTION
This PR deprecates Layabout. The rationale for deprecation can be found in [my blog post](https://tuckersiemens.com/posts/deprecating-layabout/). **TL;DR**: The `2.x` family of the official [slackclient](https://pypi.org/project/slackclient/) library includes updates that make Layabout obsolete.