### PR TITLE
Adjust README.rst to pass twine check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Layabout
     :alt: Layabout on PyPI
 
 ⚠️ Layabout is `deprecated`_. There will be no further support. ⚠️
-=================================================================
+==================================================================
 
 **Layabout** is a small event handling library on top of the Slack RTM API.
 


### PR DESCRIPTION
```
Content received from server:                                                                                                                                                
<html>                                                                                                                                                                       
 <head>                                                                                                                                                                      
  <title>400 The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.</title>   
 </head>                                                                                                                                                                     
 <body>                                                                                                                                                                      
  <h1>400 The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.</h1>         
  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>                                                                
The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.                        
                                                                                                                                                                             
                                                                                                                                                                             
 </body>                                                                                                                                                                     
</html>                                                                                                                                                                      
HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more informa
tion. for url: https://upload.pypi.org/legacy/
```
is  pretty cool response to receive from [PyPI](https://pypi.org/). Thanks, reStructuredText! :upside_down_face:

Missing one `=` in the underline for the header causes this error.
```
Checking dist/layabout-1.0.2-py3-none-any.whl: FAILED                                                                                                                        
  `long_description` has syntax errors in markup and would not be rendered on PyPI.                                                                                          
    line 29: Warning: Title underline too short.                                                                                                                             
                                                                                                                                                                             
    ⚠️ Layabout is `deprecated`_. There will be no further support. ⚠️                                                                                                         
    =================================================================                                                                                                        
  warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.                                                                                             
```